### PR TITLE
feat: add useMenuItemNavigation hook with dropdown support

### DIFF
--- a/src/hooks/useMenuItemNavigation.stories.tsx
+++ b/src/hooks/useMenuItemNavigation.stories.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import { StoryObj, Meta } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { sleep } from "utilities/helpers";
+import MenuItem from "components/MenuItem";
+import DropdownMenu from "components/DropdownMenu";
+import useMenuItemNavigation from "hooks/useMenuItemNavigation";
+import IconZap from "icons/Zap";
+import IconDotsHorizontal from "icons/DotsHorizontal";
+
+const meta: Meta = {
+	title: "Hooks/useMenuItemNavigation",
+	argTypes: {
+		circular: {
+			control: "boolean",
+			description: "Enable circular navigation (wrap around from last to first item)",
+		},
+		orientation: {
+			control: "select",
+			options: ["vertical", "horizontal"],
+			description: "Navigation orientation",
+		},
+		disabled: {
+			control: "boolean",
+			description: "Disable keyboard navigation",
+		},
+	},
+	args: {
+		circular: false,
+		orientation: "vertical",
+		disabled: false,
+	},
+};
+
+export default meta;
+
+export const simpleKeyboardNavigation: StoryObj<{
+	circular: boolean;
+	orientation: "vertical" | "horizontal";
+	disabled: boolean;
+}> = {
+	name: "simple keyboard navigation test",
+	render: (args) => {
+		const { ref } = useMenuItemNavigation({
+			circular: args.circular,
+			orientation: args.orientation,
+			disabled: args.disabled,
+		});
+
+		// Debug logging
+		React.useEffect(() => {
+			console.log("Container ref:", ref.current);
+			console.log("Navigation options:", {
+				circular: args.circular,
+				orientation: args.orientation,
+				disabled: args.disabled,
+			});
+			if (ref.current) {
+				const focusableElements = ref.current.querySelectorAll(
+					'a,button,input:not([type="hidden"]),textarea,select,details,[tabindex],[contenteditable]'
+				);
+				console.log("Focusable elements found:", focusableElements);
+			}
+		}, [ref, args.circular, args.orientation, args.disabled]);
+
+		return (
+			<div>
+				<h3>Simple Keyboard Navigation Test</h3>
+				<p>
+					Click any item to focus it, then use{" "}
+					{args.orientation === "vertical" ? "Up/Down" : "Left/Right"} arrow keys.
+					{args.circular && " Navigation wraps around from last to first item."}
+				</p>
+				<div
+					ref={ref}
+					style={{
+						display: "flex",
+						flexDirection: args.orientation === "vertical" ? "column" : "row",
+						gap: "8px",
+						maxWidth: args.orientation === "vertical" ? "300px" : "100%",
+						flexWrap: args.orientation === "horizontal" ? "wrap" : "nowrap",
+					}}
+				>
+					<MenuItem icon={IconZap} onClick={() => console.log("First item clicked")}>
+						First Item
+					</MenuItem>
+					<MenuItem onClick={() => console.log("Second item clicked")}>Second Item</MenuItem>
+					<MenuItem onClick={() => console.log("Third item clicked")}>Third Item</MenuItem>
+					<MenuItem disabled>Disabled Item</MenuItem>
+					<DropdownMenu>
+						<DropdownMenu.Trigger>
+							{(attributes) => (
+								<MenuItem attributes={attributes} icon={IconDotsHorizontal}>
+									Dropdown Menu
+								</MenuItem>
+							)}
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content>
+							<DropdownMenu.Item>Submenu Item 1</DropdownMenu.Item>
+							<DropdownMenu.Item>Submenu Item 2</DropdownMenu.Item>
+							<DropdownMenu.Item>Submenu Item 3</DropdownMenu.Item>
+						</DropdownMenu.Content>
+					</DropdownMenu>
+					<MenuItem onClick={() => console.log("Last item clicked")}>Last Item</MenuItem>
+				</div>
+			</div>
+		);
+	},
+	play: async ({ canvas, args }) => {
+		const user = userEvent.setup();
+
+		// Click first item to focus it
+		const firstItem = canvas.getByRole("button", { name: "First Item" });
+		await user.click(firstItem);
+		await waitFor(() => expect(firstItem).toHaveFocus());
+
+		const arrowKey = args.orientation === "horizontal" ? "{ArrowRight}" : "{ArrowDown}";
+		const backArrowKey = args.orientation === "horizontal" ? "{ArrowLeft}" : "{ArrowUp}";
+
+		// Navigate forward with arrow key
+		await user.keyboard(arrowKey);
+		const secondItem = canvas.getByRole("button", { name: "Second Item" });
+		await waitFor(() => expect(secondItem).toHaveFocus());
+
+		// Navigate forward again
+		await user.keyboard(arrowKey);
+		const thirdItem = canvas.getByRole("button", { name: "Third Item" });
+		await waitFor(() => expect(thirdItem).toHaveFocus());
+
+		// Navigate forward again - should skip disabled item and go to dropdown menu
+		await user.keyboard(arrowKey);
+		const dropdownTrigger = canvas.getByRole("button", { name: "Dropdown Menu" });
+		await waitFor(() => expect(dropdownTrigger).toHaveFocus());
+
+		// Test that Enter key opens the dropdown menu
+		await user.keyboard("{Enter}");
+		await waitFor(() => {
+			// Look for menu items by role instead of text
+			const bodyCanvas = within(document.body);
+			const menuItems = bodyCanvas.getAllByRole("menuitem");
+			expect(menuItems.length).toBeGreaterThan(0);
+		});
+
+		// Sleep to ensure dropdown is fully opened before closing
+		await sleep(200);
+
+		// Close the dropdown by pressing Escape
+		await user.keyboard("{Escape}");
+		await waitFor(() => {
+			// Check that dropdown content is no longer in the document
+			const bodyCanvas = within(document.body);
+			const menuItems = bodyCanvas.queryAllByRole("menuitem");
+			expect(menuItems).toHaveLength(0);
+		});
+
+		// Test that Right arrow key also opens the dropdown menu (when orientation is vertical)
+		if (args.orientation === "vertical") {
+			// Sleep to ensure dropdown is fully closed and focus is stable
+			await sleep(300);
+
+			// Ensure focus is still on the dropdown trigger
+			const dropdownTrigger = canvas.getByRole("button", { name: "Dropdown Menu" });
+			await waitFor(() => expect(dropdownTrigger).toHaveFocus());
+
+			await user.keyboard("{ArrowRight}");
+			await waitFor(() => {
+				// Look for menu items by role instead of text
+				const bodyCanvas = within(document.body);
+				const menuItems = bodyCanvas.getAllByRole("menuitem");
+				expect(menuItems.length).toBeGreaterThan(0);
+			});
+
+			// Sleep to ensure dropdown is fully opened before closing
+			await sleep(200);
+
+			// Close the dropdown again
+			await user.keyboard("{Escape}");
+			await waitFor(() => {
+				// Check that dropdown content is no longer in the document
+				const bodyCanvas = within(document.body);
+				const menuItems = bodyCanvas.queryAllByRole("menuitem");
+				expect(menuItems).toHaveLength(0);
+			});
+		}
+
+		// Navigate to last item
+		await user.keyboard(arrowKey);
+		const lastItem = canvas.getByRole("button", { name: "Last Item" });
+		await waitFor(() => expect(lastItem).toHaveFocus());
+
+		if (args.circular) {
+			// Test circular navigation - should wrap to first item
+			await user.keyboard(arrowKey);
+			await waitFor(() => expect(firstItem).toHaveFocus());
+
+			// Test circular navigation backwards - should wrap to last item
+			await user.keyboard(backArrowKey);
+			await waitFor(() => expect(lastItem).toHaveFocus());
+		} else {
+			// Test non-circular navigation - should stay at last item
+			await user.keyboard(arrowKey);
+			await waitFor(() => expect(lastItem).toHaveFocus());
+
+			// Navigate back to first
+			await user.keyboard("{Home}");
+			await waitFor(() => expect(firstItem).toHaveFocus());
+
+			// Test non-circular navigation backwards - should stay at first item
+			await user.keyboard(backArrowKey);
+			await waitFor(() => expect(firstItem).toHaveFocus());
+		}
+
+		// Test Home key
+		await user.keyboard("{Home}");
+		await waitFor(() => expect(firstItem).toHaveFocus());
+
+		// Test End key
+		await user.keyboard("{End}");
+		await waitFor(() => expect(lastItem).toHaveFocus());
+	},
+};

--- a/src/hooks/useMenuItemNavigation.ts
+++ b/src/hooks/useMenuItemNavigation.ts
@@ -1,0 +1,172 @@
+"use client";
+
+import React from "react";
+import useHotkeys from "./useHotkeys";
+import { focusFirstElement, focusLastElement } from "utilities/a11y";
+import { getFocusData, focusElement } from "utilities/a11y/focus";
+import * as keys from "constants/keys";
+
+/**
+ * Options for configuring menu item navigation behavior
+ */
+export type UseMenuItemNavigationOptions = {
+	/**
+	 * Whether keyboard navigation is disabled
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
+	 * Whether navigation should wrap around (circular)
+	 * When false, navigation stops at first/last item (matches DropdownMenu behavior)
+	 * @default false
+	 */
+	circular?: boolean;
+	/**
+	 * Navigation orientation
+	 * - 'vertical': Up/Down arrows navigate (default, matches DropdownMenu)
+	 * - 'horizontal': Left/Right arrows navigate
+	 * @default 'vertical'
+	 */
+	orientation?: "vertical" | "horizontal";
+	/**
+	 * Whether to prevent default behavior for arrow keys
+	 * Prevents page scrolling when navigating
+	 * @default true
+	 */
+	preventDefault?: boolean;
+};
+
+/**
+ * Hook that provides keyboard navigation for standalone MenuItem components.
+ *
+ * This hook enables the same keyboard navigation capabilities as DropdownMenu.Item
+ * for standalone MenuItem components in a list. It provides:
+ *
+ * - Up/Down arrow navigation between items (or Left/Right for horizontal)
+ * - Home/End keys to jump to first/last item
+ * - Proper focus management with overflow handling
+ * - RTL support (inherited from focus utilities)
+ * - Accessibility compliance
+ *
+ * @example
+ * ```tsx
+ * const MyMenuList = () => {
+ *   const { ref } = useMenuItemNavigation();
+ *
+ *   return (
+ *     <div ref={ref}>
+ *       <MenuItem>First Item</MenuItem>
+ *       <MenuItem>Second Item</MenuItem>
+ *       <MenuItem>Third Item</MenuItem>
+ *     </div>
+ *   );
+ * };
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Horizontal navigation with circular behavior
+ * const { ref } = useMenuItemNavigation({
+ *   orientation: 'horizontal',
+ *   circular: true
+ * });
+ * ```
+ *
+ * @param options Configuration options for navigation behavior
+ * @returns Object containing ref to attach to the container element
+ */
+const useMenuItemNavigation = <Element extends HTMLElement = HTMLDivElement>(
+	options: UseMenuItemNavigationOptions = {}
+) => {
+	const {
+		disabled = false,
+		orientation = "vertical",
+		preventDefault = true,
+		circular = false,
+	} = options;
+
+	// Create a ref that will be used in the hotkey functions
+	const containerRef = React.useRef<Element>(null);
+
+	// Create hotkey mappings based on orientation
+	const hotkeys = React.useMemo(() => {
+		// Helper function to focus with circular support
+		const focusWithCircular = (target: "next" | "prev") => {
+			if (!containerRef.current) return;
+			const data = getFocusData({
+				root: containerRef.current,
+				target,
+				options: {
+					circular,
+					includeNegativeTabIndex: true,
+				},
+			});
+			focusElement(data.el);
+		};
+
+		const baseHotkeys: Record<string, (() => void) | null> = {
+			[keys.LEFT]: null,
+			[keys.RIGHT]: null,
+			[keys.UP]: null,
+			[keys.DOWN]: null,
+			[keys.HOME]: () => {
+				console.log("HOME key pressed, focusing first element");
+				if (containerRef.current) focusFirstElement(containerRef.current);
+			},
+			[keys.END]: () => {
+				console.log("END key pressed, focusing last element");
+				if (containerRef.current) focusLastElement(containerRef.current);
+			},
+		};
+
+		if (orientation === "horizontal") {
+			baseHotkeys[keys.LEFT] = () => {
+				console.log("LEFT key pressed, focusing previous element");
+				focusWithCircular("prev");
+			};
+			baseHotkeys[keys.RIGHT] = () => {
+				console.log("RIGHT key pressed, focusing next element");
+				focusWithCircular("next");
+			};
+		} else {
+			// Default vertical orientation (matches DropdownMenu behavior)
+			baseHotkeys[keys.UP] = () => {
+				console.log("UP key pressed, focusing previous element");
+				focusWithCircular("prev");
+			};
+			baseHotkeys[keys.DOWN] = () => {
+				console.log("DOWN key pressed, focusing next element");
+				focusWithCircular("next");
+			};
+			// In vertical mode, Right arrow opens dropdown menus
+			baseHotkeys[keys.RIGHT] = () => {
+				const activeElement = document.activeElement;
+
+				// Check if current focused element is a dropdown trigger
+				if (activeElement?.getAttribute("aria-haspopup") === "menu") {
+					console.log("RIGHT key pressed on dropdown trigger, opening dropdown");
+					(activeElement as HTMLElement).click();
+					return;
+				}
+
+				console.log("RIGHT key pressed, no action (vertical orientation)");
+			};
+		}
+
+		return baseHotkeys;
+	}, [orientation, circular]);
+
+	useHotkeys(
+		hotkeys,
+		[orientation, circular], // Re-create hotkeys when orientation or circular changes
+		{
+			disabled,
+			preventDefault,
+			ref: containerRef,
+		}
+	);
+
+	return { ref: containerRef };
+};
+
+export default useMenuItemNavigation;

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,7 @@ export { default as useHandlerRef } from "hooks/useHandlerRef";
 export { default as useHotkeys } from "hooks/useHotkeys";
 export { default as useIsomorphicLayoutEffect } from "hooks/useIsomorphicLayoutEffect";
 export { default as useKeyboardMode } from "hooks/useKeyboardMode";
+export { default as useMenuItemNavigation } from "hooks/useMenuItemNavigation";
 export { default as useOnClickOutside } from "hooks/useOnClickOutside";
 export { default as useResponsiveClientValue } from "hooks/useResponsiveClientValue";
 export { default as useRTL } from "hooks/useRTL";


### PR DESCRIPTION
## Summary
- Create useMenuItemNavigation hook for keyboard navigation between MenuItem components
- Support vertical/horizontal orientation, circular navigation, and disabled state
- Add Right arrow key integration to open dropdown menus via aria-haspopup detection
- Include comprehensive Storybook stories with interactive controls and test coverage
- Export hook from main index for public API



## Related Issue
#436 

## Screenshots / Recordings

https://github.com/user-attachments/assets/2aebe6ef-22e3-4001-a7c5-aefbf0a548a7



## Checklist
- [x] Tested changes in storybook
- [x] Added/updated tests
- [x] Verified accessibility (where applicable)
- [x] Commit message follows gitflow notation, e.g. `fix(Button): fixed text label position`

## Notes for Reviewers
<!-- Anything specific reviewers should focus on -->
