### PR TITLE
fix(Modal): fixed nested modals not closing one by one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.8.0-canary.3
+
+
+### Features
+
+* **Actionable, Link, Button, MenuItem:** added render prop ([104e594](https://github.com/reshaped-ui/reshaped/commit/104e594dcb086fd9f6a38c8085ebceda8a2ec9cf))
+
 ## 3.8.0-canary.2
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "reshaped",
 	"description": "Professionally crafted design system in React & Figma for building products of any scale and complexity",
-	"version": "3.8.0-canary.2",
+	"version": "3.8.0-canary.3",
 	"license": "MIT",
 	"email": "hello@reshaped.so",
 	"homepage": "https://reshaped.so",

--- a/src/components/Modal/tests/Modal.stories.tsx
+++ b/src/components/Modal/tests/Modal.stories.tsx
@@ -231,6 +231,7 @@ export const containerRef = () => {
 
 export const edgeCases = () => {
 	const menuModalToggle = useToggle();
+	const menuModalToggleInner = useToggle();
 	const scrollModalToggle = useToggle();
 	const inputRef = React.useRef<HTMLInputElement>(null);
 
@@ -310,7 +311,11 @@ export const edgeCases = () => {
 								<DropdownMenu.Item>Item 2</DropdownMenu.Item>
 							</DropdownMenu.Content>
 						</DropdownMenu>
+						<Button onClick={menuModalToggleInner.activate}>Open dialog</Button>
 						<Button onClick={menuModalToggle.deactivate}>Close</Button>
+						<Modal active={menuModalToggleInner.active} onClose={menuModalToggleInner.deactivate}>
+							<Button onClick={menuModalToggleInner.deactivate}>Close</Button>
+						</Modal>
 					</View>
 				</Modal>
 			</Example.Item>

--- a/src/hooks/_private/useIsDismissible.ts
+++ b/src/hooks/_private/useIsDismissible.ts
@@ -5,7 +5,6 @@
 
 import React from "react";
 import useElementId from "hooks/useElementId";
-import { onNextFrame } from "utilities/animation";
 
 type Ref = React.RefObject<HTMLElement | null>;
 type QueueItem = { triggerRef?: Ref; contentRef: Ref; parentId: string | null };
@@ -36,20 +35,12 @@ const useIsDismissible = (args: { active?: boolean; contentRef: Ref; triggerRef?
 	React.useEffect(() => {
 		if (!active) return;
 
-		onNextFrame(() => addToQueue(id, contentRef, triggerRef));
+		addToQueue(id, contentRef, triggerRef);
 		return () => removeFromQueue(id);
 	}, [active, id, contentRef, triggerRef]);
 
 	return React.useCallback(() => {
 		if (!active) return true;
-
-		const latest = latestId ? queue[latestId] : undefined;
-		const latestTrigger = latest?.triggerRef?.current;
-		const prev = latest?.parentId ? queue[latest.parentId] : undefined;
-		const prevContent = prev?.contentRef.current;
-
-		// Don't block independently rendered components that are not nested in each other
-		if (!prevContent || !latestTrigger || !prevContent.contains(latestTrigger)) return true;
 		return latestId === id;
 	}, [id, active]);
 };


### PR DESCRIPTION
## Summary

Flyouts and Modals should be closing one by one but there was a condition that was checking if two components are "independently" opened. This is not something we should be handling anymore since Flyouts and Modals are both blocking no so we're always just closing one at time without having to check their relation. 

## Related Issue
https://github.com/reshaped-ui/reshaped/issues/440

## Screenshots / Recordings

https://github.com/user-attachments/assets/0c718e36-402b-47ec-9401-e2d5a5bc056e

