### PR TITLE
feat(Icon): blank icon support

### DIFF
--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -15,13 +15,13 @@ const Icon: React.FC<T.Props> = (props) => {
 		autoWidth && s["--auto"]
 	);
 
-	const icon = React.isValidElement(Component) ? Component : <Component />;
+	const icon = React.isValidElement(Component) || Component === null ? Component : <Component />;
 	const style = { ...attributes?.style, ...mixinStyles.variables };
 
 	return (
 		// All icons are decorative, a11y attributes should be set for buttons wrapping them
 		<span {...attributes} aria-hidden="true" className={rootClassName} style={style}>
-			{React.cloneElement(icon, { focusable: false })}
+			{icon && React.cloneElement(icon, { focusable: false })}
 		</span>
 	);
 };

--- a/src/components/Icon/Icon.types.ts
+++ b/src/components/Icon/Icon.types.ts
@@ -3,7 +3,7 @@ import type * as G from "types/global";
 
 export type Props = {
 	/** Icon svg component or node */
-	svg: React.ReactElement | React.ComponentType;
+	svg: React.ReactElement | React.ComponentType | null;
 	/** Icon size, literal css value or unit token multiplier */
 	size?: G.Responsive<number | string>;
 	/** Icon color, based on the color tokens */

--- a/src/components/Icon/tests/Icon.stories.tsx
+++ b/src/components/Icon/tests/Icon.stories.tsx
@@ -77,7 +77,7 @@ export const color = {
 };
 
 export const autoWidth = {
-	name: "autoWidth",
+	name: "autoWidth, blank",
 	render: () => (
 		<Example>
 			<Example.Item title="square boundaries">
@@ -88,6 +88,11 @@ export const autoWidth = {
 			<Example.Item title="auto width boundaries">
 				<div style={{ background: "var(--rs-color-background-neutral)", display: "inline-block" }}>
 					<Icon svg={IconMic} size={10} autoWidth />
+				</div>
+			</Example.Item>
+			<Example.Item title="blank">
+				<div style={{ background: "var(--rs-color-background-neutral)", display: "inline-block" }}>
+					<Icon svg={null} size={10} />
 				</div>
 			</Example.Item>
 		</Example>


### PR DESCRIPTION
## Summary

Adding a blank icon support when passing `svg={null}` so that it can reserve the space when rendered next to other elements with rendered icons

## Screenshots / Recordings

<img width="234" height="432" alt="image" src="https://github.com/user-attachments/assets/e026335b-f2f2-4627-b447-b0fa0a6dac22" />
