### PR TITLE
feat(ToggleButtonGroup): add selectedColor and color props with border coordination

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -396,6 +396,23 @@
 	&.--variant-ghost.--color-white {
 		--rs-button-group-separator-color: rgba(var(--rs-color-rgb-white), 0.28);
 	}
+
+	/* Right border color overrides for adjacent selected buttons */
+	&.--right-border-primary {
+		border-inline-end-color: var(--rs-color-border-primary-faded);
+	}
+
+	&.--right-border-critical {
+		border-inline-end-color: var(--rs-color-border-critical-faded);
+	}
+
+	&.--right-border-positive {
+		border-inline-end-color: var(--rs-color-border-positive-faded);
+	}
+
+	&.--right-border-neutral {
+		border-inline-end-color: var(--rs-color-border-neutral);
+	}
 }
 
 /* Button aligner */

--- a/src/components/ToggleButton/ToggleButtonControlled.tsx
+++ b/src/components/ToggleButton/ToggleButtonControlled.tsx
@@ -5,9 +5,16 @@ import Button, { ButtonProps } from "components/Button";
 import { useToggleButtonGroup } from "components/ToggleButtonGroup";
 
 const ToggleButtonControlled: React.FC<T.ControlledProps> = (props) => {
-	const { variant = "outline", value, onChange, onClick, ...buttonProps } = props;
+	const { variant = "outline", value, onChange, onClick, color, ...buttonProps } = props;
 	const toggleButtonGroup = useToggleButtonGroup();
 	const checked = (value ? toggleButtonGroup?.value?.includes(value) : undefined) ?? props.checked;
+
+	// Determine the color to use based on priority:
+	// 1. Individual button color (highest priority)
+	// 2. Group selectedColor (when checked/highlighted)
+	// 3. Group color (fallback)
+	const effectiveColor =
+		color || (checked && toggleButtonGroup?.selectedColor) || toggleButtonGroup?.color;
 
 	const handleClick: ButtonProps["onClick"] = (event) => {
 		const changeArgs = { checked: !checked, value: value ?? "", event };
@@ -25,6 +32,7 @@ const ToggleButtonControlled: React.FC<T.ControlledProps> = (props) => {
 		<Button
 			{...buttonProps}
 			variant={variant}
+			color={effectiveColor}
 			onClick={handleClick}
 			highlighted={checked}
 			attributes={{ ...buttonProps.attributes, "aria-pressed": checked }}

--- a/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts
+++ b/src/components/ToggleButtonGroup/ToggleButtonGroup.types.ts
@@ -1,5 +1,5 @@
 import type React from "react";
-import type { ButtonGroupProps } from "components/Button";
+import type { ButtonGroupProps, ButtonProps } from "components/Button";
 import type { ToggleButtonProps } from "components/ToggleButton";
 
 type BaseProps = {
@@ -12,6 +12,15 @@ type BaseProps = {
 		value: string[];
 		event: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
 	}) => void;
+	/** Component color scheme for all buttons in the group
+	 * Individual button colors take priority over this
+	 * @default "neutral"
+	 */
+	color?: ButtonProps["color"];
+	/** Component color scheme for selected buttons in the group
+	 * Individual button colors take priority over this
+	 */
+	selectedColor?: ButtonProps["color"];
 } & ButtonGroupProps;
 
 export type ControlledProps = BaseProps & {
@@ -31,4 +40,6 @@ export type Props = ControlledProps | UncontrolledProps;
 export type Context = {
 	onChange: ToggleButtonProps["onChange"];
 	value?: string[];
+	color?: ButtonProps["color"];
+	selectedColor?: ButtonProps["color"];
 };

--- a/src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx
+++ b/src/components/ToggleButtonGroup/tests/ToggleButtonGroup.stories.tsx
@@ -3,6 +3,7 @@ import { expect, fn, Mock, userEvent } from "storybook/test";
 import { Example } from "utilities/storybook";
 import ToggleButtonGroup from "components/ToggleButtonGroup";
 import ToggleButton from "components/ToggleButton";
+import View from "components/View";
 
 export default {
 	title: "Components/ToggleButtonGroup",
@@ -150,6 +151,79 @@ export const multiple: StoryObj<{
 			event: expect.objectContaining({ target: controlledButton2 }),
 		});
 	},
+};
+
+export const selectedColor: StoryObj = {
+	name: "selectedColor",
+	render: () => (
+		<Example>
+			<Example.Item title="selectedColor: primary">
+				<ToggleButtonGroup selectedColor="primary" defaultValue={["1"]}>
+					<ToggleButton value="1">Button 1</ToggleButton>
+					<ToggleButton value="2">Button 2</ToggleButton>
+					<ToggleButton value="3">Button 3</ToggleButton>
+				</ToggleButtonGroup>
+			</Example.Item>
+			<Example.Item title="color: neutral, selectedColor: primary">
+				<ToggleButtonGroup color="neutral" selectedColor="primary" defaultValue={["1"]}>
+					<ToggleButton value="1">Button 1</ToggleButton>
+					<ToggleButton value="2">Button 2</ToggleButton>
+					<ToggleButton value="3">Button 3</ToggleButton>
+				</ToggleButtonGroup>
+			</Example.Item>
+			<Example.Item title="priority: individual color overrides group colors">
+				<ToggleButtonGroup color="neutral" selectedColor="primary" defaultValue={["2"]}>
+					<ToggleButton value="1">Button 1</ToggleButton>
+					<ToggleButton value="2" color="critical">
+						Button 2 (critical)
+					</ToggleButton>
+					<ToggleButton value="3">Button 3</ToggleButton>
+				</ToggleButtonGroup>
+			</Example.Item>
+			<Example.Item title="multiple selection with selectedColor">
+				<ToggleButtonGroup
+					selectionMode="multiple"
+					selectedColor="positive"
+					defaultValue={["1", "3"]}
+				>
+					<ToggleButton value="1">Button 1</ToggleButton>
+					<ToggleButton value="2">Button 2</ToggleButton>
+					<ToggleButton value="3">Button 3</ToggleButton>
+				</ToggleButtonGroup>
+			</Example.Item>
+			<Example.Item title="all selectedColors">
+				<View gap={2}>
+					{(["primary", "critical", "positive", "neutral"] as const).map((selectedColor) => (
+						<ToggleButtonGroup
+							key={selectedColor}
+							selectedColor={selectedColor}
+							defaultValue={["1"]}
+						>
+							<ToggleButton value="1">Selected: {selectedColor}</ToggleButton>
+							<ToggleButton value="2">Button 2</ToggleButton>
+							<ToggleButton value="3">Button 3</ToggleButton>
+						</ToggleButtonGroup>
+					))}
+				</View>
+			</Example.Item>
+			<Example.Item title="all colors with selectedColor: primary">
+				<View gap={2}>
+					{(["neutral", "primary", "critical", "positive"] as const).map((color) => (
+						<ToggleButtonGroup
+							key={color}
+							color={color}
+							selectedColor="primary"
+							defaultValue={["1"]}
+						>
+							<ToggleButton value="1">{color} 1</ToggleButton>
+							<ToggleButton value="2">{color} 2</ToggleButton>
+							<ToggleButton value="3">{color} 3</ToggleButton>
+						</ToggleButtonGroup>
+					))}
+				</View>
+			</Example.Item>
+		</Example>
+	),
 };
 
 export const className: StoryObj = {


### PR DESCRIPTION
## Summary

- Add `color` prop to set default color for all buttons in the group
- Add `selectedColor` prop to set color for selected/highlighted buttons
- Implement color priority system: individual button color > selectedColor > group color
- Add border coordination to ensure visual consistency around selected buttons
- Support both single and multiple selection modes
- Add comprehensive Storybook examples demonstrating all color combinations and priority scenarios

## Related Issue
Resolves #432

## Screenshots / Recordings
https://github.com/user-attachments/assets/cfe2c829-7c4a-48f3-a8ad-e7ec7f8460b9
