### PR TITLE
fix: cli theming import path after cjs removal

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,7 @@ const path = require("path");
 const process = require("process");
 const chalk = require("chalk");
 const { Command } = require("commander");
-const { addTheme, addThemeFragment } = require("../dist/cjs/cli/theming");
+const { addTheme, addThemeFragment } = require("../dist/cli/theming");
 
 const program = new Command();
 


### PR DESCRIPTION
## Summary
After https://github.com/reshaped-ui/reshaped/pull/473 there is no commonjs build/export anymore, this produce an error when using the CLI.   
Version: `3.8.4-canary.1`  

I'm using the canary version because I'm in an ESM env, `"type": "module"`, and on the latest version this does not work (fixed in #473). `import { generateThemeColors } from 'reshaped/themes'`.   

## Screenshots / Recordings
`reshaped theming --output src/themes`   

Produce the following error (stripped).   

`Error: Cannot find module '../dist/cjs/cli/theming`   