### PR TITLE
fix: main entry point for commonjs with require(esm) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js"
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
 		},
 		"./themes": {
 			"types": "./dist/themes/index.d.ts",


### PR DESCRIPTION
## Summary

Our current env is: 
* Webpack latest (we generate client and server side, SSR bundles)
* Node.js 22.14
* Reshaped 3.8.5

## Related Issue
I get the following error, when processing the server bundle.  
This is because only an `import` conditional entry point is declared.  
Server side we are most likely still using commonjs, but are benefiting from Node.js > 22.12 `require(ESM)` capabilities.   
Although the  `import` conditional entry point is not used by `require(ESM)`.   

## Screenshots / Recordings

```js
import { Reshaped } from 'reshaped';
```
```sh
Module not found: Error: Package path . is not exported from package
[...]/node_modules/reshaped (see exports field in[...]/node_modules/reshaped/package.js
```

## Notes for Reviewers

This diff fixes my immediate issue, but this is probably expandable to all others entry points.   

Correct me if I'm wrong but, since there is no commonjs build anymore provided by Reshaped, this means Reshaped is not supporting Node.js versions lower than 22.12. Except if we were to recompile it in our builds.    

So we could also convert all `import` keys into `default`, this would have the same effect.   
Or just keep `import` and add `default`, pointing to the same file.    
I could amend this PR to change all entry points if you think so.   