### PR TITLE
fix(Select): support native optgroup elements

### DIFF
--- a/.changeset/chubby-yaks-shave.md
+++ b/.changeset/chubby-yaks-shave.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Fix Select component to support native optgroup elements. The component now correctly recognizes `<optgroup>` elements as valid containers for options, allowing native select dropdowns to render with grouped options.

--- a/packages/reshaped/src/components/Select/Select.tsx
+++ b/packages/reshaped/src/components/Select/Select.tsx
@@ -15,7 +15,9 @@ const Select: React.FC<T.NativeProps> = (props) => {
 			{(props) => {
 				const { options } = props;
 				const hasOptionChildren = React.Children.toArray(children).some((child) => {
-					return React.isValidElement(child) && child.type === "option";
+					return (
+						React.isValidElement(child) && (child.type === "option" || child.type === "optgroup")
+					);
 				});
 				const hasOptions = Boolean(options || hasOptionChildren);
 

--- a/packages/reshaped/src/components/Select/tests/Select.stories.tsx
+++ b/packages/reshaped/src/components/Select/tests/Select.stories.tsx
@@ -76,6 +76,52 @@ export const nativeRender: StoryObj = {
 	},
 };
 
+export const nativeOptgroup: StoryObj = {
+	name: "native with optgroup",
+	render: () => (
+		<Example>
+			<Example.Item title="native with optgroup">
+				<Select
+					name="animal"
+					id="animal-optgroup"
+					placeholder="Select an animal"
+					inputAttributes={{
+						"aria-label": "Select an animal",
+					}}
+				>
+					<optgroup label="Mammals">
+						<option value="dog">Dog</option>
+						<option value="cat">Cat</option>
+					</optgroup>
+					<optgroup label="Reptiles">
+						<option value="turtle">Turtle</option>
+						<option value="lizard">Lizard</option>
+					</optgroup>
+				</Select>
+			</Example.Item>
+		</Example>
+	),
+	play: ({ canvas }) => {
+		const select = canvas.getByRole("combobox");
+		const options = within(select).getAllByRole("option");
+		const optgroups = within(select).getAllByRole("group");
+
+		expect(select).toHaveAttribute("name", "animal");
+		expect(select).toHaveAttribute("id", "animal-optgroup");
+
+		// Should have 2 optgroups
+		expect(optgroups).toHaveLength(2);
+
+		// Should have 5 options total (1 placeholder + 4 options)
+		expect(options).toHaveLength(5);
+		expect(options[0]).toHaveTextContent("Select an animal");
+		expect(options[1]).toHaveTextContent("Dog");
+		expect(options[2]).toHaveTextContent("Cat");
+		expect(options[3]).toHaveTextContent("Turtle");
+		expect(options[4]).toHaveTextContent("Lizard");
+	},
+};
+
 export const customRender: StoryObj = {
 	name: "custom rendering, name, id, option groups",
 	render: () => (


### PR DESCRIPTION
## Summary
<!-- Briefly describe the changes -->
The Select component now correctly recognizes <optgroup> elements as valid containers for options, allowing native select dropdowns to render with grouped options.

- Updated hasOptionChildren check to include optgroup elements
- Added test case for native optgroup support
- All unit tests passing

## Related Issue
<!-- Link to the issue number if applicable -->
https://github.com/reshaped-ui/reshaped/issues/560

## Screenshots / Recordings
<!-- If UI changes, add before/after screenshots or a short recording -->
<img width="416" height="271" alt="image" src="https://github.com/user-attachments/assets/2bfbb9df-b38e-427c-863e-1ec05ad113c3" />

## Notes for Reviewers
<!-- Anything specific reviewers should focus on -->
