### PR TITLE
feat(themes): add semantic control radius tokens

### DIFF
--- a/packages/reshaped/src/components/Button/Button.module.css
+++ b/packages/reshaped/src/components/Button/Button.module.css
@@ -137,7 +137,7 @@
 		--rs-button-line-height: var(--rs-line-height-body-3);
 		--rs-button-font-size: var(--rs-font-size-body-3);
 		--rs-button-letter-spacing: var(--rs-letter-spacing-body-3);
-		--rs-button-radius: var(--rs-radius-small);
+		--rs-button-radius: var(--rs-radius-control-small);
 	}
 
 	@value medium {
@@ -147,7 +147,7 @@
 		--rs-button-line-height: var(--rs-line-height-body-3);
 		--rs-button-font-size: var(--rs-font-size-body-3);
 		--rs-button-letter-spacing: var(--rs-letter-spacing-body-3);
-		--rs-button-radius: var(--rs-radius-small);
+		--rs-button-radius: var(--rs-radius-control-medium);
 	}
 
 	@value large {
@@ -157,7 +157,7 @@
 		--rs-button-line-height: var(--rs-line-height-body-2);
 		--rs-button-font-size: var(--rs-font-size-body-2);
 		--rs-button-letter-spacing: var(--rs-letter-spacing-body-2);
-		--rs-button-radius: var(--rs-radius-medium);
+		--rs-button-radius: var(--rs-radius-control-large);
 	}
 
 	@value xlarge {
@@ -167,7 +167,7 @@
 		--rs-button-line-height: var(--rs-line-height-body-2);
 		--rs-button-font-size: var(--rs-font-size-body-2);
 		--rs-button-letter-spacing: var(--rs-letter-spacing-body-2);
-		--rs-button-radius: var(--rs-radius-medium);
+		--rs-button-radius: var(--rs-radius-control-xlarge);
 	}
 }
 

--- a/packages/reshaped/src/components/MenuItem/MenuItem.module.css
+++ b/packages/reshaped/src/components/MenuItem/MenuItem.module.css
@@ -43,7 +43,7 @@ button.root {
 	@value small {
 		--rs-p-v: var(--rs-unit-x1);
 		--rs-p-h: var(--rs-unit-x2);
-		--rs-menu-item-radius: var(--rs-radius-small);
+		--rs-menu-item-radius: var(--rs-radius-control-small);
 
 		font-size: var(--rs-font-size-body-3);
 		line-height: var(--rs-line-height-body-3);
@@ -53,7 +53,7 @@ button.root {
 	@value medium {
 		--rs-p-v: var(--rs-unit-x2);
 		--rs-p-h: var(--rs-unit-x3);
-		--rs-menu-item-radius: var(--rs-radius-small);
+		--rs-menu-item-radius: var(--rs-radius-control-medium);
 
 		font-size: var(--rs-font-size-body-3);
 		line-height: var(--rs-line-height-body-3);
@@ -63,7 +63,7 @@ button.root {
 	@value large {
 		--rs-p-v: var(--rs-unit-x3);
 		--rs-p-h: var(--rs-unit-x4);
-		--rs-menu-item-radius: var(--rs-radius-medium);
+		--rs-menu-item-radius: var(--rs-radius-control-large);
 
 		font-size: var(--rs-font-size-body-2);
 		line-height: var(--rs-line-height-body-2);

--- a/packages/reshaped/src/components/Select/Select.module.css
+++ b/packages/reshaped/src/components/Select/Select.module.css
@@ -105,7 +105,7 @@
 	@value small {
 		--rs-select-gap: var(--rs-unit-x2);
 		--rs-select-chevron-size: var(--rs-unit-x4);
-		--rs-select-radius: var(--rs-radius-small);
+		--rs-select-radius: var(--rs-radius-control-small);
 
 		& .input {
 			padding-block: var(--rs-unit-x1);
@@ -118,7 +118,7 @@
 	@value medium {
 		--rs-select-gap: var(--rs-unit-x2);
 		--rs-select-chevron-size: var(--rs-unit-x4);
-		--rs-select-radius: var(--rs-radius-small);
+		--rs-select-radius: var(--rs-radius-control-medium);
 
 		& .input {
 			padding-block: var(--rs-unit-x2);
@@ -131,7 +131,7 @@
 	@value large {
 		--rs-select-gap: var(--rs-unit-x3);
 		--rs-select-chevron-size: var(--rs-unit-x5);
-		--rs-select-radius: var(--rs-radius-medium);
+		--rs-select-radius: var(--rs-radius-control-large);
 
 		& .input {
 			padding-block: var(--rs-unit-x3);
@@ -144,7 +144,7 @@
 	@value xlarge {
 		--rs-select-gap: var(--rs-unit-x4);
 		--rs-select-chevron-size: var(--rs-unit-x5);
-		--rs-select-radius: var(--rs-radius-medium);
+		--rs-select-radius: var(--rs-radius-control-xlarge);
 
 		& .input {
 			padding-block: var(--rs-unit-x4);

--- a/packages/reshaped/src/components/TextArea/TextArea.module.css
+++ b/packages/reshaped/src/components/TextArea/TextArea.module.css
@@ -34,7 +34,7 @@
 	z-index: 1;
 	color: var(--rs-color-foreground-neutral);
 	background: var(--rs-color-background-elevation-base);
-	border-radius: var(--rs-radius-small);
+	border-radius: var(--rs-radius-control-medium);
 	box-shadow: 0 0 0 var(--rs-textarea-border-width) var(--rs-textarea-border-color) inset;
 
 	&:focus {
@@ -54,7 +54,7 @@
 		--rs-p: var(--rs-unit-x2);
 
 		& .input {
-			border-radius: var(--rs-radius-small);
+			border-radius: var(--rs-radius-control-medium);
 			font-size: var(--rs-font-size-body-3);
 			line-height: var(--rs-line-height-body-3);
 			letter-spacing: var(--rs-letter-spacing-body-3);
@@ -65,7 +65,7 @@
 		--rs-p: var(--rs-unit-x3);
 
 		& .input {
-			border-radius: var(--rs-radius-medium);
+			border-radius: var(--rs-radius-control-large);
 			font-size: var(--rs-font-size-body-2);
 			line-height: var(--rs-line-height-body-2);
 			letter-spacing: var(--rs-letter-spacing-body-2);
@@ -76,7 +76,7 @@
 		--rs-p: var(--rs-unit-x4);
 
 		& .input {
-			border-radius: var(--rs-radius-medium);
+			border-radius: var(--rs-radius-control-xlarge);
 			font-size: var(--rs-font-size-body-2);
 			line-height: var(--rs-line-height-body-2);
 			letter-spacing: var(--rs-letter-spacing-body-2);

--- a/packages/reshaped/src/components/TextField/TextField.module.css
+++ b/packages/reshaped/src/components/TextField/TextField.module.css
@@ -156,7 +156,7 @@
 @responsive .--size {
 	@value small {
 		--rs-text-field-gap: var(--rs-unit-x2);
-		--rs-text-field-radius: var(--rs-radius-small);
+		--rs-text-field-radius: var(--rs-radius-control-small);
 		--rs-text-field-p-v: var(--rs-unit-x1);
 		--rs-text-field-font-size: var(--rs-font-size-body-3);
 		--rs-text-field-line-height: var(--rs-line-height-body-3);
@@ -167,7 +167,7 @@
 
 	@value medium {
 		--rs-text-field-gap: var(--rs-unit-x2);
-		--rs-text-field-radius: var(--rs-radius-small);
+		--rs-text-field-radius: var(--rs-radius-control-medium);
 		--rs-text-field-p-v: var(--rs-unit-x2);
 		--rs-text-field-font-size: var(--rs-font-size-body-3);
 		--rs-text-field-line-height: var(--rs-line-height-body-3);
@@ -178,7 +178,7 @@
 
 	@value large {
 		--rs-text-field-gap: var(--rs-unit-x3);
-		--rs-text-field-radius: var(--rs-radius-medium);
+		--rs-text-field-radius: var(--rs-radius-control-large);
 		--rs-text-field-p-v: var(--rs-unit-x3);
 		--rs-text-field-font-size: var(--rs-font-size-body-2);
 		--rs-text-field-line-height: var(--rs-line-height-body-2);
@@ -189,7 +189,7 @@
 
 	@value xlarge {
 		--rs-text-field-gap: var(--rs-unit-x4);
-		--rs-text-field-radius: var(--rs-radius-medium);
+		--rs-text-field-radius: var(--rs-radius-control-xlarge);
 		--rs-text-field-p-v: var(--rs-unit-x4);
 		--rs-text-field-font-size: var(--rs-font-size-body-2);
 		--rs-text-field-line-height: var(--rs-line-height-body-2);

--- a/packages/reshaped/src/themes/_generator/tokens/radius/radius.transforms.ts
+++ b/packages/reshaped/src/themes/_generator/tokens/radius/radius.transforms.ts
@@ -1,13 +1,28 @@
+import { getVariableName } from "../css";
+
 import type * as T from "./radius.types";
 import type { Transformer } from "../types";
 
-const transformToken: Transformer<T.Token> = (name, token) => [
-	{
-		name,
-		tokenType: "radius",
-		type: "variable",
-		value: `${token.px}px`,
-	},
-];
+const transformToken: Transformer<T.Token> = (name, token) => {
+	if ("radiusToken" in token) {
+		return [
+			{
+				name,
+				tokenType: "radius",
+				type: "variable",
+				value: `var(${getVariableName(token.radiusToken, "radius")})`,
+			},
+		];
+	}
+
+	return [
+		{
+			name,
+			tokenType: "radius",
+			type: "variable",
+			value: `${token.px}px`,
+		},
+	];
+};
 
 export default transformToken;

--- a/packages/reshaped/src/themes/_generator/tokens/radius/radius.types.ts
+++ b/packages/reshaped/src/themes/_generator/tokens/radius/radius.types.ts
@@ -1,2 +1,10 @@
-export type Name = "small" | "medium" | "large";
-export type Token = { px: number };
+export type Name =
+	| "small"
+	| "medium"
+	| "large"
+	| "control-small"
+	| "control-medium"
+	| "control-large"
+	| "control-xlarge";
+
+export type Token = { px: number } | { radiusToken: string };

--- a/packages/reshaped/src/themes/figma/theme.json
+++ b/packages/reshaped/src/themes/figma/theme.json
@@ -217,6 +217,18 @@
     },
     "large": {
       "px": 12
+    },
+    "control-small": {
+      "radiusToken": "small"
+    },
+    "control-medium": {
+      "radiusToken": "small"
+    },
+    "control-large": {
+      "radiusToken": "medium"
+    },
+    "control-xlarge": {
+      "radiusToken": "medium"
     }
   },
   "color": {

--- a/packages/reshaped/src/themes/reshaped/theme.json
+++ b/packages/reshaped/src/themes/reshaped/theme.json
@@ -208,6 +208,18 @@
     },
     "large": {
       "px": 12
+    },
+    "control-small": {
+      "radiusToken": "small"
+    },
+    "control-medium": {
+      "radiusToken": "small"
+    },
+    "control-large": {
+      "radiusToken": "medium"
+    },
+    "control-xlarge": {
+      "radiusToken": "medium"
     }
   },
   "color": {

--- a/packages/reshaped/src/themes/slate/theme.json
+++ b/packages/reshaped/src/themes/slate/theme.json
@@ -208,6 +208,18 @@
     },
     "large": {
       "px": 12
+    },
+    "control-small": {
+      "radiusToken": "small"
+    },
+    "control-medium": {
+      "radiusToken": "small"
+    },
+    "control-large": {
+      "radiusToken": "medium"
+    },
+    "control-xlarge": {
+      "radiusToken": "medium"
     }
   },
   "color": {


### PR DESCRIPTION
## Summary

- Adds `control-small`, `control-medium`, `control-large`, and `control-xlarge` radius tokens
- Allows theme authors to customize border-radius for interactive controls independently from general radius values
- Components updated: Button, TextField, TextArea, Select, MenuItem

## Problem

Currently, components like Button have hardcoded size-to-radius mappings (e.g., small buttons always use `--rs-radius-small`). Theme authors cannot customize how "rounded" interactive controls appear without affecting non-control elements that use the same base radius tokens.

## Solution

Introduce semantic `control-*` radius tokens that default to referencing existing radius tokens but can be overridden by theme authors:

```json
"radius": {
  "control-small": { "radiusToken": "small" },
  "control-medium": { "radiusToken": "small" },
  "control-large": { "radiusToken": "medium" },
  "control-xlarge": { "radiusToken": "medium" }
}
```

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Unit tests pass (`pnpm test:unit`)
- [ ] Visual inspection in Storybook for affected components
- [ ] Verify theme customization works by overriding control tokens

🤖 Generated with [Claude Code](https://claude.ai/claude-code)