### PR TITLE
fix: prevent mixing responsive viewport keys with T's keys in Responsive<T>

### DIFF
--- a/packages/reshaped/src/types/global.ts
+++ b/packages/reshaped/src/types/global.ts
@@ -1,7 +1,12 @@
 import React from "react";
 
 export type Viewport = "s" | "m" | "l" | "xl";
-export type ResponsiveOnly<T> = { [key in Viewport]?: T };
+
+// if ResponsiveOnly<T> is { [key in Viewport]?: T } without the intersection and T is an object such as ButtonProps,
+// Responsive<T> would allow mixing keys of T with viewport keys without any type error
+export type ResponsiveOnly<T> = { [key in Viewport]?: T } & (T extends object
+	? { [K in Exclude<keyof T & string, Viewport>]?: never }
+	: Record<never, never>);
 export type Responsive<T> = T | ResponsiveOnly<T>;
 
 /**


### PR DESCRIPTION
Hi, first of all, congrats on and thanks for opensourcing reshaped, really enjoying digging the codebase.

I noticed a small type safety gap in `Responsive<T>` and wanted to contribute a fix.

## Summary

Regarding `ResponsiveOnly<T>`, currently when `T` is an object like `ButtonProps`, it allows mixing `T`'s keys with viewport keys without a type error.

```ts
const buttonProps = useResponsiveClientValue<ButtonProps>({
  s: { variant: "solid" },
  xl: { variant: "outline" },
  onClick: () => {},  // no error
});
```

This PR adds an intersection to `ResponsiveOnly<T>` so that `T`'s own keys would be mapped to `never`.

## Related Issue

not found so far

## Notes for Reviewers

While this makes codes like above make type error, IDE still suggests `T`'s keys in autocompletions. I guess this is a TypeScript limitation.