### PR TITLE
useIsDismissible: defer queue removal and expose as private export

### DIFF
--- a/packages/reshaped/package.json
+++ b/packages/reshaped/package.json
@@ -70,7 +70,12 @@
     "./themes/slate/*": "./dist/themes/slate/*",
     "./themes/figma/*": "./dist/themes/figma/*",
     "./themes/fragments/twitter/*": "./dist/themes/fragments/twitter/*",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./_private/useIsDismissible": {
+      "types": "./dist/hooks/_private/useIsDismissible.d.ts",
+      "import": "./dist/hooks/_private/useIsDismissible.js",
+      "default": "./dist/hooks/_private/useIsDismissible.js"
+    }
   },
   "bin": {
     "reshaped": "./bin/cli.js"

--- a/packages/reshaped/src/hooks/_private/useIsDismissible.ts
+++ b/packages/reshaped/src/hooks/_private/useIsDismissible.ts
@@ -42,7 +42,13 @@ const useIsDismissible = (args: {
 		if (!active) return;
 
 		addToQueue(id, contentRef, triggerRef);
-		return () => removeFromQueue(id);
+		// Defer removal so the queue stays intact during the same event tick.
+		// Without this, a child overlay closing synchronously removes itself before
+		// a parent overlay's useOnClickOutside handler checks isDismissible(),
+		// causing both to close instead of just the child.
+		return () => {
+			setTimeout(() => removeFromQueue(id), 0);
+		};
 	}, [active, id, contentRef, triggerRef]);
 
 	return React.useCallback(() => {


### PR DESCRIPTION
## Summary
Expose useIsDismissible for consumers to inter-op. Cleanup on next tick for better integration with react lifecycle.
