### PR TITLE
feat(Toast): containerRef and global show option

### DIFF
--- a/.changeset/toast-provider-container-ref.md
+++ b/.changeset/toast-provider-container-ref.md
@@ -2,4 +2,4 @@
 "reshaped": minor
 ---
 
-ToastProvider: Added `containerRef` prop to render toast regions into a specific DOM element
+ToastProvider: Added `containerRef` prop to render toast regions into a specific DOM element, and a `global` option in `show` to render a toast in the root provider, ignoring any nested provider's `containerRef`

--- a/.changeset/toast-provider-container-ref.md
+++ b/.changeset/toast-provider-container-ref.md
@@ -1,0 +1,5 @@
+---
+"reshaped": minor
+---
+
+ToastProvider: Added `containerRef` prop to render toast regions into a specific DOM element

--- a/packages/reshaped/src/components/Toast/Toast.constants.ts
+++ b/packages/reshaped/src/components/Toast/Toast.constants.ts
@@ -26,4 +26,5 @@ export const defaultContextData = {
 	hide: () => {},
 	remove: () => {},
 	add: () => "",
+	root: null,
 };

--- a/packages/reshaped/src/components/Toast/Toast.types.ts
+++ b/packages/reshaped/src/components/Toast/Toast.types.ts
@@ -49,6 +49,8 @@ export type ProviderProps = {
 			}
 		>
 	>;
+	/** Container to render the toast regions in using a portal, must be CSS-positioned */
+	containerRef?: React.RefObject<HTMLElement | null>;
 };
 
 export type RegionProps = {

--- a/packages/reshaped/src/components/Toast/Toast.types.ts
+++ b/packages/reshaped/src/components/Toast/Toast.types.ts
@@ -66,7 +66,12 @@ export type ContainerProps = {
 	inspected: boolean;
 };
 
-export type ShowOptions = { timeout?: Timeout; position?: Position };
+export type ShowOptions = {
+	timeout?: Timeout;
+	position?: Position;
+	/** Render the toast in the root provider, ignoring any nested provider's */
+	global?: boolean;
+};
 export type ShowProps = Props & ShowOptions;
 
 export type Context = {
@@ -74,9 +79,16 @@ export type Context = {
 	queues: Record<RegionProps["position"], Array<ContainerProps>>;
 	add: (toast: ShowProps) => string;
 	show: (id: string) => void;
-	hide: (id: string) => void;
+	hide: (id: string, options?: { global?: boolean }) => void;
 	remove: (id: string) => void;
 	id: string;
+	/** Topmost provider in the tree, used to render global toasts */
+	root: RootContext | null;
+};
+
+export type RootContext = {
+	add: (toast: ShowProps) => string;
+	hide: (id: string) => void;
 };
 
 type AddAction = {

--- a/packages/reshaped/src/components/Toast/ToastProvider.tsx
+++ b/packages/reshaped/src/components/Toast/ToastProvider.tsx
@@ -7,7 +7,6 @@ import { positions, defaultContextData } from "./Toast.constants";
 import ToastContext from "./Toast.context";
 import * as T from "./Toast.types";
 import ToastRegion from "./ToastRegion";
-import useToast from "./useToast";
 
 let counter = 0;
 const generateId = () => `__rs-toast-${counter++}`;
@@ -67,24 +66,46 @@ const toastReducer: T.Reducer = (state, action) => {
 
 const ToastProvider: React.FC<T.ProviderProps> = (props) => {
 	const { children, options, containerRef } = props;
-	const toast = useToast();
+	const parent = React.useContext(ToastContext);
 	const id = React.useId();
 	const [data, dispatch] = React.useReducer(toastReducer, defaultContextData.queues);
 
-	const add = React.useCallback<T.Context["add"]>((toastProps) => {
+	const localAdd = React.useCallback((toastProps: T.ShowProps) => {
 		const id = generateId();
 
 		dispatch({ type: "add", payload: { toastProps, id } });
 		return id;
 	}, []);
 
+	const localHide = React.useCallback((id: string) => {
+		dispatch({ type: "hide", payload: { id } });
+	}, []);
+
+	// Topmost provider in the tree — global toasts are delegated here
+	const root = React.useMemo<T.RootContext>(
+		() => parent.root ?? { add: localAdd, hide: localHide },
+		[parent.root, localAdd, localHide]
+	);
+
+	const add = React.useCallback<T.Context["add"]>(
+		(toastProps) => {
+			if (toastProps.global) return root.add(toastProps);
+			return localAdd(toastProps);
+		},
+		[root, localAdd]
+	);
+
 	const show = React.useCallback((id: string) => {
 		dispatch({ type: "show", payload: { id } });
 	}, []);
 
-	const hide = React.useCallback((id: string) => {
-		dispatch({ type: "hide", payload: { id } });
-	}, []);
+	const hide = React.useCallback<T.Context["hide"]>(
+		(id, hideOptions) => {
+			if (hideOptions?.global) return root.hide(id);
+			return localHide(id);
+		},
+		[root, localHide]
+	);
 
 	const remove = React.useCallback((id: string) => {
 		dispatch({ type: "remove", payload: { id } });
@@ -100,12 +121,13 @@ const ToastProvider: React.FC<T.ProviderProps> = (props) => {
 			remove,
 			inspecting: false,
 			options,
+			root,
 		}),
-		[data, show, hide, add, remove, id, options]
+		[data, show, hide, add, remove, id, options, root]
 	);
 
 	const regions = positions.map((position) => (
-		<ToastRegion position={position} key={position} nested={!!toast.id} />
+		<ToastRegion position={position} key={position} nested={!!parent.id} />
 	));
 
 	const portalTarget = containerRef?.current ?? null;

--- a/packages/reshaped/src/components/Toast/ToastProvider.tsx
+++ b/packages/reshaped/src/components/Toast/ToastProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { createPortal } from "react-dom";
 
 import { positions, defaultContextData } from "./Toast.constants";
 import ToastContext from "./Toast.context";
@@ -65,7 +66,7 @@ const toastReducer: T.Reducer = (state, action) => {
 };
 
 const ToastProvider: React.FC<T.ProviderProps> = (props) => {
-	const { children, options } = props;
+	const { children, options, containerRef } = props;
 	const toast = useToast();
 	const id = React.useId();
 	const [data, dispatch] = React.useReducer(toastReducer, defaultContextData.queues);
@@ -103,12 +104,16 @@ const ToastProvider: React.FC<T.ProviderProps> = (props) => {
 		[data, show, hide, add, remove, id, options]
 	);
 
+	const regions = positions.map((position) => (
+		<ToastRegion position={position} key={position} nested={!!toast.id} />
+	));
+
+	const portalTarget = containerRef?.current ?? null;
+
 	return (
 		<ToastContext.Provider value={value}>
 			{children}
-			{positions.map((position) => (
-				<ToastRegion position={position} key={position} nested={!!toast.id} />
-			))}
+			{portalTarget ? createPortal(<>{regions}</>, portalTarget) : regions}
 		</ToastContext.Provider>
 	);
 };

--- a/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
+++ b/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryObj } from "@storybook/react-vite";
+import React from "react";
 import { expect, userEvent, within } from "storybook/test";
 
 import Button from "@/components/Button";
@@ -545,4 +546,62 @@ export const edgeCases = {
 			</Example.Item>
 		</Example>
 	),
+};
+
+const ContainerRefDemo = () => {
+	const toast = useToast();
+
+	return (
+		<Button
+			onClick={() => {
+				toast.show({
+					text: "Content",
+					position: "top-start",
+				});
+			}}
+		>
+			Show toast
+		</Button>
+	);
+};
+
+export const containerRef: StoryObj = {
+	name: "containerRef",
+	render: () => {
+		const ref = React.useRef<HTMLDivElement>(null);
+
+		return (
+			<Example>
+				<Example.Item title="containerRef, regions portalled into target container">
+					<ToastProvider containerRef={ref}>
+						<View gap={4} align="start">
+							<ContainerRefDemo />
+							<View
+								attributes={{
+									ref,
+									"data-testid": "test-container-ref-id",
+								}}
+								position="relative"
+								backgroundColor="neutral-faded"
+								borderRadius="medium"
+								width="100%"
+								minHeight={50}
+							/>
+						</View>
+					</ToastProvider>
+				</Example.Item>
+			</Example>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement.ownerDocument.body);
+		const button = canvas.getAllByRole("button")[0];
+
+		await userEvent.click(button);
+
+		const container = canvas.getByTestId("test-container-ref-id");
+		const toast = within(container).getByText("Content");
+
+		expect(toast).toBeInTheDocument();
+	},
 };

--- a/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
+++ b/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
@@ -605,3 +605,61 @@ export const containerRef: StoryObj = {
 		expect(toast).toBeInTheDocument();
 	},
 };
+
+const GlobalDemo = () => {
+	const toast = useToast();
+
+	return (
+		<Button
+			onClick={() => {
+				toast.show({
+					text: "Global content",
+					position: "top-start",
+					global: true,
+				});
+			}}
+		>
+			Show toast
+		</Button>
+	);
+};
+
+export const global: StoryObj = {
+	name: "global",
+	render: () => {
+		const ref = React.useRef<HTMLDivElement>(null);
+
+		return (
+			<Example>
+				<Example.Item title="global, renders in the root provider ignoring containerRef">
+					<ToastProvider containerRef={ref}>
+						<View gap={4} align="start">
+							<GlobalDemo />
+							<View
+								attributes={{ ref, "data-testid": "test-global-container-id" }}
+								position="relative"
+								backgroundColor="neutral-faded"
+								borderRadius="medium"
+								width="100%"
+								minHeight={50}
+							/>
+						</View>
+					</ToastProvider>
+				</Example.Item>
+			</Example>
+		);
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement.ownerDocument.body);
+		const button = canvas.getAllByRole("button")[0];
+
+		await userEvent.click(button);
+
+		const toast = canvas.getByText("Global content");
+		const container = canvas.getByTestId("test-global-container-id");
+
+		// Global toast renders outside the containerRef target
+		expect(toast).toBeInTheDocument();
+		expect(container).not.toContainElement(toast);
+	},
+};


### PR DESCRIPTION
## Summary

Two related additions to `<ToastProvider>` / `useToast`, both about decoupling **where toasts are rendered** from **where the provider sits in the React tree**:

**1. `containerRef` prop on `<ToastProvider>`**

When provided, toast regions are rendered into the referenced DOM element via `ReactDOM.createPortal` instead of inline next to `children`.

- **Context scope** (which `useToast()` consumers see the provider) — still follows the React tree, unchanged.
- **DOM position of the toast regions** — can now be anchored to an arbitrary CSS-positioned element.

Mirrors the existing `containerRef` pattern already used by `<Flyout>`.

**2. `global` option in `show`**

`toast.show({ ..., global: true })` renders the toast in the root provider, ignoring any nested provider's `containerRef`. Useful when your whole app is wrapped in a `containerRef` provider but you occasionally need a toast on top of everything (e.g. a critical error), without restructuring the tree. `toast.hide(id, { global: true })` mirrors it.

## Screenshots / Recordings
<img width="830" height="534" alt="image" src="https://github.com/user-attachments/assets/850a01e7-cce6-41e6-83f5-e8d072e78520" />

## Notes for Reviewers

- `containerRef` is additive (~10 lines in `ToastProvider.tsx`); no changes to `ToastRegion`, `useToast`, or `Toast.module.css`. The target element must be CSS-positioned (documented in the prop's JSDoc), since the nested region relies on `position: absolute`.
- `global` works by each provider tracking the topmost provider in the chain via context; `show`/`hide` delegate there when the flag is set. Only `add`/`hide` are global-aware (the public API) — `show`/`remove` are internal lifecycle calls handled by the root region itself.
- Two Storybook stories (`containerRef`, `global`) cover both the visual demo and the `play()` assertions.
- Changeset added (minor bump).