### PR TITLE
fix(ci): pin pnpm to 11.3.0 and migrate to allowBuilds

### DIFF
--- a/.changeset/pin-pnpm-allow-builds.md
+++ b/.changeset/pin-pnpm-allow-builds.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Pin pnpm to 11.3.0 across CI and migrate the build-script allowlist to the new `allowBuilds` setting, since pnpm 11 removed `ignoredBuiltDependencies`. This unblocks installs in CI.

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,8 +27,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -56,8 +54,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -99,8 +95,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -143,8 +137,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -181,8 +173,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -226,8 +216,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4
@@ -259,8 +247,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       - name: Restore node_modules cache
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Get package name and version from tag
         id: tag_info

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
 		"vitest-browser-react": "2.0.5"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=22",
+		"pnpm": ">=11"
 	},
 	"size-limit": [
 		{
@@ -111,5 +112,6 @@
 			"path": "packages/reshaped/dist/tests/themingWithDefinition.js",
 			"webpack": true
 		}
-	]
+	],
+	"packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - "packages/**"
 
-ignoredBuiltDependencies:
-  - esbuild
-  - lefthook
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  unrs-resolver: true


### PR DESCRIPTION
## Summary

CI is broken — `pnpm install` fails on any PR because `pnpm/action-setup` uses `version: latest`, which is now pnpm 11. pnpm 11 removed the `ignoredBuiltDependencies` setting, so install exits with an error on every run.

This fixes it by replacing `ignoredBuiltDependencies` with the new `allowBuilds` map, pinning pnpm to 11.3.0 via `packageManager`, and removing hardcoded `version:` from all workflows. Also fixes `release.yml` which was still stuck on pnpm 9.

## Notes for Reviewers

Two checks will be red, but neither is caused by this PR:

- **test-size** - it checks out `canary` to compare bundle sizes, but `canary` still has the broken config. Will go green once this merges.
- **test-browser (Overlay/Modal)** - pre-existing failure on clean `canary` without any of my changes. The `onAfterOpen` test fails when the full shard runs (there's even a `// TODO: Fails CLI tests in Storybook without a timeout` in that test already).