### PR TITLE
feat(Toast): iconPosition

### DIFF
--- a/.changeset/toast-icon-position.md
+++ b/.changeset/toast-icon-position.md
@@ -1,0 +1,5 @@
+---
+"reshaped": minor
+---
+
+Toast: Added `iconPosition` prop to control the icon placement relative to the content (start/end, top/center)

--- a/packages/reshaped/src/components/Toast/Toast.module.css
+++ b/packages/reshaped/src/components/Toast/Toast.module.css
@@ -143,3 +143,14 @@
 		width: 360px;
 	}
 }
+
+.icon {
+	&--position-start-top,
+	&--position-end-top {
+		align-self: flex-start;
+	}
+
+	&--position-end-center {
+		align-self: center;
+	}
+}

--- a/packages/reshaped/src/components/Toast/Toast.tsx
+++ b/packages/reshaped/src/components/Toast/Toast.tsx
@@ -22,10 +22,13 @@ const Toast: React.FC<T.Props & { collapsed: boolean }> = (props) => {
 		title,
 		actionsSlot,
 		startSlot,
+		iconPosition = "start-center",
 		collapsed,
 		className,
 		attributes,
 	} = props;
+	const isIconAtEnd = iconPosition.startsWith("end-");
+
 	let backgroundColor: ViewProps["backgroundColor"] =
 		color === "inverted" || color === "neutral" ? "elevation-overlay" : color;
 	if (color === "neutral") backgroundColor = collapsed ? "neutral" : "elevation-overlay";
@@ -51,6 +54,10 @@ const Toast: React.FC<T.Props & { collapsed: boolean }> = (props) => {
 		</React.Fragment>
 	);
 
+	const iconNode = icon && (
+		<Icon size={5} svg={icon} className={s[`icon--position-${iconPosition}`]} />
+	);
+
 	const toastNode = (
 		<View
 			backgroundColor={backgroundColor}
@@ -64,8 +71,8 @@ const Toast: React.FC<T.Props & { collapsed: boolean }> = (props) => {
 			className={[s.toast, className]}
 			attributes={attributes}
 		>
-			{icon && <Icon size={5} svg={icon} className={s.icon} />}
-			{startSlot && !icon && <View.Item>{startSlot}</View.Item>}
+			{!isIconAtEnd && iconNode}
+			{startSlot && (!icon || isIconAtEnd) && <View.Item>{startSlot}</View.Item>}
 
 			<View.Item grow>
 				<View direction={isLarge ? "column" : "row"} align={isLarge ? "start" : "center"} gap={3}>
@@ -103,6 +110,7 @@ const Toast: React.FC<T.Props & { collapsed: boolean }> = (props) => {
 					)}
 				</View>
 			</View.Item>
+			{isIconAtEnd && iconNode}
 		</View>
 	);
 

--- a/packages/reshaped/src/components/Toast/Toast.types.ts
+++ b/packages/reshaped/src/components/Toast/Toast.types.ts
@@ -14,6 +14,10 @@ export type Props = {
 	size?: "small" | "medium" | "large";
 	/** Icon at the inline start position of the toast */
 	icon?: IconProps["svg"];
+	/** Position of the icon relative to the content
+	 * @default "start-center"
+	 */
+	iconPosition?: "start-center" | "start-top" | "end-center" | "end-top";
 	/** Node for inserting content at the inline start position of the toast */
 	startSlot?: React.ReactNode;
 	/** Title value for the toast */

--- a/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
+++ b/packages/reshaped/src/components/Toast/tests/Toast.stories.tsx
@@ -381,6 +381,75 @@ const Slots = () => {
 };
 export const slots = { name: "slots", render: () => <Slots /> };
 
+const IconPosition = () => {
+	const toast = useToast();
+	const props = {
+		icon: IconZap,
+		title: "Hey!",
+		text: "Very long event completed notification message that spans multiple lines",
+		size: "medium" as const,
+	};
+
+	return (
+		<Example>
+			<Example.Item title="iconPosition: start-center (default)">
+				<Button
+					onClick={() => {
+						toast.show({ ...props });
+					}}
+				>
+					Show toast
+				</Button>
+			</Example.Item>
+			<Example.Item title="iconPosition: start-top">
+				<Button
+					onClick={() => {
+						toast.show({ ...props, iconPosition: "start-top" });
+					}}
+				>
+					Show toast
+				</Button>
+			</Example.Item>
+			<Example.Item title="iconPosition: end-center">
+				<Button
+					onClick={() => {
+						toast.show({ ...props, iconPosition: "end-center" });
+					}}
+				>
+					Show toast
+				</Button>
+			</Example.Item>
+			<Example.Item title="iconPosition: end-top">
+				<Button
+					onClick={() => {
+						toast.show({ ...props, iconPosition: "end-top" });
+					}}
+				>
+					Show toast
+				</Button>
+			</Example.Item>
+			<Example.Item title="iconPosition: end-center with startSlot">
+				<Button
+					onClick={() => {
+						toast.show({
+							...props,
+							iconPosition: "end-center",
+							startSlot: "Slot",
+						});
+					}}
+				>
+					Show toast
+				</Button>
+			</Example.Item>
+		</Example>
+	);
+};
+
+export const iconPosition = {
+	name: "iconPosition",
+	render: () => <IconPosition />,
+};
+
 export const base: StoryObj = {
 	name: "base",
 	render: () => {


### PR DESCRIPTION
## Summary

Adds an optional `iconPosition` prop to Toast to control where the icon is placed relative to the content. Supports `"start-center"`, `"start-top"`, `"end-center"`, `"end-top"`.

By default, the icon sits at the inline start, aligned by the toast size. With `iconPosition` you can pin it to the top for multi-line content, or move it to the inline end.

Closes #605

## Related Issue

#605

## Screenshots / Recordings

<img width="989" height="571" alt="image" src="https://github.com/user-attachments/assets/3acfa134-8e5a-4bd6-8c25-d9b6a77b524c" />

## Notes for Reviewers

- Only affects `icon`, not `startSlot` (users can wrap `startSlot` themselves).
- When `icon` is at the end, `startSlot` can be used alongside it.
- Default `"start-center"` keeps the existing behavior.
- Changeset added (minor bump).