### PR TITLE
fix(skills): link to  latest v3 version for v3 to v4 skills

### DIFF
--- a/skills/reshaped-v3-v4/changes/scrim-removed.md
+++ b/skills/reshaped-v3-v4/changes/scrim-removed.md
@@ -6,4 +6,4 @@ description: Removed component from the library
 ## Manual migration
 
 Copy the component source from the previous major version:
-https://github.com/reshaped-ui/reshaped/tree/canary/packages/reshaped/src/components/Scrim
+https://github.com/reshaped-ui/reshaped/tree/reshaped%403.10.3/packages/reshaped/src/components/Scrim

--- a/skills/reshaped-v3-v4/changes/stepper-removed.md
+++ b/skills/reshaped-v3-v4/changes/stepper-removed.md
@@ -6,4 +6,4 @@ description: Removed component from the library
 ## Manual migration
 
 Copy the component source from the previous major version:
-https://github.com/reshaped-ui/reshaped/blob/canary/packages/reshaped/src/components/Stepper
+https://github.com/reshaped-ui/reshaped/tree/reshaped%403.10.3/packages/reshaped/src/components/Stepper

--- a/skills/reshaped-v3-v4/changes/timeline-removed.md
+++ b/skills/reshaped-v3-v4/changes/timeline-removed.md
@@ -6,4 +6,4 @@ description: Removed component from the library
 ## Manual migration
 
 Copy the component source from the previous major version:
-https://github.com/reshaped-ui/reshaped/tree/canary/packages/reshaped/src/components/Timeline
+https://github.com/reshaped-ui/reshaped/tree/reshaped%403.10.3/packages/reshaped/src/components/Timeline


### PR DESCRIPTION
## Summary

Current skills links for removed components points to the canary branch, which leads to 404s.  

## Notes for Reviewers

I picked the `3.10.3` tag which seems to be the latest stable one on the 3x branch.   
