### PR TITLE
fix(Calendar): prevent month navigation from skipping months

### DIFF
--- a/.changeset/fix-calendar-month-overflow.md
+++ b/.changeset/fix-calendar-month-overflow.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Calendar: Fixed month navigation skipping months when the anchor date is on a high day-of-month (e.g. the 31st)

--- a/packages/reshaped/src/components/Calendar/Calendar.utils.ts
+++ b/packages/reshaped/src/components/Calendar/Calendar.utils.ts
@@ -104,10 +104,7 @@ export const changeDate = (date: Date, delta: number) =>
 	new Date(date.getFullYear(), date.getMonth(), date.getDate() + delta);
 
 export const setMonthTo = (date: Date, value: number) => {
-	const resultDate = new Date(date);
-
-	resultDate.setMonth(value);
-	return resultDate;
+	return new Date(date.getFullYear(), value, 1);
 };
 
 export const setMonthToPrevious = (date: Date) => {


### PR DESCRIPTION
## Problem
`setMonthTo` (used by `setMonthToNext`/`setMonthToPrevious`) mutated a copy of the anchor date with `Date.prototype.setMonth`, which keeps the original day-of-month. When the anchor date falls on the 29th–31st, `setMonth` overflows into the following month:

- Anchor `Jan 31` → `setMonth(1)` → `Feb 31` → normalizes to **`Mar 3`**

So clicking "next month" from a month while the anchor date is on a high day-of-month **skips a month** (e.g. January jumps straight to March, skipping February). The default anchor is `new Date()` (today), so this reproduces for any user on the 29th–31st, or whenever a consumer passes a `month`/`defaultMonth` Date with a high day-of-month.

## Fix
Anchor the result on the 1st of the target month, which can never overflow:

```diff
 export const setMonthTo = (date: Date, value: number) => {
-	const resultDate = new Date(date);
-
-	resultDate.setMonth(value);
-	return resultDate;
+	return new Date(date.getFullYear(), value, 1);
 };
```

`new Date(year, value, 1)` also handles year wrap-around correctly (`value = -1` → December of the previous year, `value = 12` → January of the next). Downstream consumers (`getMonthWeeks`) already recompute from day 1, so dropping the day-of-month is safe.

## Before / After
```
next-month from Jan 31 2025:
  before: 2025-03-03  (skips February!)
  after : 2025-02-01
prev-month from Mar 31 2025:
  before: 2025-03-03  (skips February!)
  after : 2025-02-01
```

## How to test
1. Set your system clock to the 31st (or render `<Calendar defaultMonth={new Date(2025, 0, 31)} />`).
2. Open the Calendar and click the "next month" chevron.
3. **Before:** January → March. **After:** January → February.

Found during a full package bug review. Related Calendar fixes (Next-button bounds, `firstWeekDay` cell placement) are submitted as separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_