### PR TITLE
fix(Calendar): keep Next button visible on navigable months

### DIFF
--- a/.changeset/fix-calendar-nav-bounds.md
+++ b/.changeset/fix-calendar-nav-bounds.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Calendar: Fixed the Next button being hidden on navigable months when the anchor date is on a high day-of-month

--- a/packages/reshaped/src/components/Calendar/Calendar.utils.ts
+++ b/packages/reshaped/src/components/Calendar/Calendar.utils.ts
@@ -138,7 +138,7 @@ export const applyNavigationBounds = (args: { date: Date; min?: Date; max?: Date
 	const currentMonth = date.getMonth();
 	const currentYear = date.getFullYear();
 	const prevMonthLastDate = new Date(currentYear, currentMonth, 0);
-	const nextMonthFirstDate = setMonthToNext(date);
+	const nextMonthFirstDate = new Date(currentYear, currentMonth + 1, 1);
 	nextMonthFirstDate.setDate(0);
 
 	return {


### PR DESCRIPTION
## Problem
`applyNavigationBounds` derived its next-month reference date with `setMonthToNext(date)`, which keeps the day-of-month and overflows for high days:

- Anchor `Jan 31` → `setMonthToNext` → `Mar 3` → `setDate(0)` → **`Feb 28`** (should be `Jan 31`)

With a `max` date that lies inside the genuinely-navigable next month, the wrong reference makes `isLastMonth` true and **hides the Next button on a month the user should still be able to navigate to**.

(`prevMonthLastDate` already uses the safe `new Date(year, month, 0)` form and is unaffected.)

## Fix
Build the reference from the 1st of the next month, which can't overflow; `setDate(0)` then correctly yields the last day of the current month:

```diff
 const prevMonthLastDate = new Date(currentYear, currentMonth, 0);
-const nextMonthFirstDate = setMonthToNext(date);
-nextMonthFirstDate.setDate(0);
+const nextMonthFirstDate = new Date(currentYear, currentMonth + 1, 1);
+nextMonthFirstDate.setDate(0);
```

## Before / After
```
anchor Jan 31, max = Feb 15  ->  is Next hidden?
  before: nextRef = 2025-02-28 | hidden = true   (bug: Feb is navigable)
  after : nextRef = 2025-01-31 | hidden = false
```

## How to test
1. Render `<Calendar defaultMonth={new Date(2025, 0, 31)} max={new Date(2025, 1, 15)} />`.
2. **Before:** the Next chevron is hidden/disabled in January even though February is within range. **After:** Next is available and navigates to February.

Found during a full package bug review. This shares a root cause (`setMonth` overflow) with the separate `setMonthTo` PR; both are scoped independently so either can merge first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_