### PR TITLE
fix(Calendar): correct day-cell placement for firstWeekDay >= 2

### DIFF
--- a/.changeset/fix-calendar-firstweekday.md
+++ b/.changeset/fix-calendar-firstweekday.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Calendar: Fixed day cell placement being misaligned for firstWeekDay values of 2 or more

--- a/packages/reshaped/src/components/Calendar/Calendar.utils.ts
+++ b/packages/reshaped/src/components/Calendar/Calendar.utils.ts
@@ -21,7 +21,7 @@ const getNormalizedDay = (args: { date: Date; firstWeekDay?: number }) => {
 
 	const day = date.getDay();
 
-	return day < firstWeekDay ? DAYS_IN_WEEK - day - firstWeekDay : day - firstWeekDay;
+	return (day - firstWeekDay + DAYS_IN_WEEK) % DAYS_IN_WEEK;
 };
 
 /**


### PR DESCRIPTION
## Problem
`getNormalizedDay` maps a JS weekday (`0`–`6`, Sunday-based) to a column index relative to `firstWeekDay`:

```ts
return day < firstWeekDay ? DAYS_IN_WEEK - day - firstWeekDay : day - firstWeekDay;
```

The `day < firstWeekDay` branch only yields correct columns for `firstWeekDay` of `0` or `1`. For `firstWeekDay >= 2` it collides two days onto the same column and leaves a gap, so the day grid becomes **misaligned with the weekday header** (and the leading/trailing `null` fills in `getMonthWeeks` are miscounted).

## Fix
Use modular arithmetic, which is correct for any first weekday:

```diff
-return day < firstWeekDay ? DAYS_IN_WEEK - day - firstWeekDay : day - firstWeekDay;
+return (day - firstWeekDay + DAYS_IN_WEEK) % DAYS_IN_WEEK;
```

## Before / After (column index per weekday)
```
firstWeekDay=1   (unchanged — backward compatible)
  before: Su:6 Mo:0 Tu:1 We:2 Th:3 Fr:4 Sa:5
  after : Su:6 Mo:0 Tu:1 We:2 Th:3 Fr:4 Sa:5
firstWeekDay=2
  before: Su:5 Mo:4 Tu:0 We:1 Th:2 Fr:3 Sa:4   <- Mon & Sat both col 4, col 6 missing
  after : Su:5 Mo:6 Tu:0 We:1 Th:2 Fr:3 Sa:4
firstWeekDay=3
  before: Su:4 Mo:3 Tu:2 We:0 Th:1 Fr:2 Sa:3   <- collisions
  after : Su:4 Mo:5 Tu:6 We:0 Th:1 Fr:2 Sa:3
```

## How to test
1. Render `<Calendar firstWeekDay={2} />` (Tuesday-first).
2. **Before:** day numbers don't line up under their weekday headers (some columns doubled, one empty). **After:** every date sits under the correct weekday.
3. `firstWeekDay` 0 and 1 are unchanged.

Found during a full package bug review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_