### PR TITLE
fix(Toast): don't render a stray 0 when there are no actions

### DIFF
--- a/.changeset/fix-toast-stray-zero.md
+++ b/.changeset/fix-toast-stray-zero.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Toast: Fixed a stray "0" being rendered when the toast has no actions

--- a/packages/reshaped/src/components/Toast/Toast.tsx
+++ b/packages/reshaped/src/components/Toast/Toast.tsx
@@ -82,7 +82,7 @@ const Toast: React.FC<T.Props & { collapsed: boolean }> = (props) => {
 						)}
 					</View.Item>
 
-					{actions.length && (
+					{actions.length > 0 && (
 						<View direction="row" align="center" gap={2}>
 							{actions.map((slot, index) => {
 								const defaultProps: Partial<ButtonProps> = {


### PR DESCRIPTION
## Problem
```tsx
{actions.length && (
  <View ...>{actions.map(...)}</View>
)}
```
When `actions` is empty, `actions.length` is `0`. In JSX, `0 && X` evaluates to `0`, and React **renders the number `0`** as a text node (unlike `false`/`null`/`undefined`, which render nothing). So every toast without an `actionsSlot` displays a stray `0`.

## Fix
```diff
-{actions.length && (
+{actions.length > 0 && (
```

## Before / After
- **Before:** a toast with no actions renders a literal `0` next to its content.
- **After:** nothing is rendered when there are no actions.

## How to test
1. Show a toast with no `actions`/`actionsSlot` (e.g. `toast.show({ text: "Saved" })`).
2. **Before:** a `0` appears in the toast. **After:** no stray character.

Found during a full package bug review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_