### PR TITLE
fix(Toast): clear auto-dismiss timer on unmount

### DIFF
--- a/.changeset/fix-toast-timer-leak.md
+++ b/.changeset/fix-toast-timer-leak.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Toast: Fixed the auto-dismiss timer not being cleared on unmount, which could fire hide/remove for an already-removed toast

--- a/packages/reshaped/src/components/Toast/ToastContainer.tsx
+++ b/packages/reshaped/src/components/Toast/ToastContainer.tsx
@@ -58,6 +58,8 @@ const ToastContainer: React.FC<T.ContainerProps> = (props) => {
 		}, timeoutValue ?? timeouts.short);
 	}, [hide, id, remove, timeout, stopTimer]);
 
+	React.useEffect(() => stopTimer, [stopTimer]);
+
 	const handleTransitionEnd = (e: React.TransitionEvent) => {
 		if (e.propertyName !== "height") return;
 


### PR DESCRIPTION
## Problem
`ToastContainer` schedules an auto-dismiss timer via `startTimer` (a `setTimeout` stored in `timeoutRef`) that calls `hide(id)` / `remove(id)`. No effect cleanup ever cleared that timer on unmount. If a toast is removed before the timeout fires — a programmatic `remove()`, or rapid add/remove churn — the pending timer still fires `hide`/`remove` for an id that no longer exists.

## Fix
Add an unmount cleanup that stops the timer:

```diff
 }, [hide, id, remove, timeout, stopTimer]);

+// Clear any pending auto-dismiss timer on unmount so it can't fire hide/remove
+// for a toast that has already been removed.
+React.useEffect(() => stopTimer, [stopTimer]);
+
 const handleTransitionEnd = (e: React.TransitionEvent) => {
```

`stopTimer` is a stable `useCallback`, so the effect's cleanup runs on unmount (and clears the active timeout via `clearTimeout`).

## Before / After
- **Before:** removing a toast before its timeout leaves a dangling `setTimeout` that later calls `hide`/`remove` on a gone id.
- **After:** the timer is cleared as soon as the toast unmounts.

## How to test
1. Show a toast with a long `timeout`, then `remove()` it immediately (or unmount the tree).
2. **Before:** a delayed `hide`/`remove` still fires later. **After:** no late callback.

Found during a full package bug review. Touches the same file as the Toast focus-trap-leak PR — that one is submitted separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_