### PR TITLE
fix(Toast): release focus trap on unmount

### DIFF
--- a/.changeset/fix-toast-focustrap-leak.md
+++ b/.changeset/fix-toast-focustrap-leak.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Toast: Fixed the focus trap leaking on unmount, which could leave focus trapped after the toast was gone

--- a/packages/reshaped/src/components/Toast/ToastContainer.tsx
+++ b/packages/reshaped/src/components/Toast/ToastContainer.tsx
@@ -85,18 +85,15 @@ const ToastContainer: React.FC<T.ContainerProps> = (props) => {
 	}, [show, id, startTimer]);
 
 	React.useEffect(() => {
-		if (!wrapperRef.current) return;
+		if (!wrapperRef.current || !visible) return;
 
 		const trapFocus = new TrapFocus();
+		trapFocus.trap(wrapperRef.current, {
+			includeTrigger: true,
+			mode: "content-menu",
+		});
 
-		if (visible) {
-			trapFocus.trap(wrapperRef.current, {
-				includeTrigger: true,
-				mode: "content-menu",
-			});
-		} else if (checkKeyboardMode()) {
-			trapFocus.release();
-		}
+		return () => trapFocus.release({ withoutFocusReturn: !checkKeyboardMode() });
 	}, [visible]);
 
 	React.useEffect(() => {


### PR DESCRIPTION
## Problem
The focus-trap effect builds a `TrapFocus` and `trap()`s it whenever `visible` becomes true, but returns **no cleanup**. As a result a visible toast that unmounts (e.g. removed programmatically) leaks the `TrapFocus` and its document-level listeners, and can leave focus trapped after the toast is gone.

The existing `else if (checkKeyboardMode()) { trapFocus.release(); }` branch *looked* like it released the trap, but it ran on a **freshly-constructed instance that was never trapped**, so `release()` immediately returned at its guard (`if (!this.trapped || ...) return;`) — it was a no-op. The instance that was actually trapped (in a prior `visible === true` run) was only reachable via that run's cleanup, which didn't exist.

## Fix
Only trap when visible, and release in the cleanup (which closes over the instance that was actually trapped). Preserve the original intent of the `checkKeyboardMode()` guard — return focus to the trigger only for keyboard users — via `withoutFocusReturn`:

```diff
 React.useEffect(() => {
-	if (!wrapperRef.current) return;
-
-	const trapFocus = new TrapFocus();
-
-	if (visible) {
-		trapFocus.trap(wrapperRef.current, {
-			includeTrigger: true,
-			mode: "content-menu",
-		});
-	} else if (checkKeyboardMode()) {
-		trapFocus.release();
-	}
-
-	return () => trapFocus.release();
+	if (!wrapperRef.current || !visible) return;
+
+	const trapFocus = new TrapFocus();
+	trapFocus.trap(wrapperRef.current, {
+		includeTrigger: true,
+		mode: "content-menu",
+	});
+
+	return () => trapFocus.release({ withoutFocusReturn: !checkKeyboardMode() });
 }, [visible]);
```

This also removes the dead `else if` branch.

## Verification
- `tsc -p tsconfig.esm.json --noEmit` → 0 errors. `oxlint` → clean.

## How to test
1. Keyboard: tab into a visible toast, then dismiss/remove it → focus returns to the trigger; no trap/listeners remain.
2. Mouse: let a toast auto-dismiss → focus is not yanked back (`withoutFocusReturn` when not in keyboard mode).
3. Unmount a visible toast (remove it / unmount the tree) → trap is released, no leak.

Found during a full package bug review.