### PR TITLE
fix(Slider): allow range max thumb to swap when min thumb is at 0

### DIFF
--- a/.changeset/fix-slider-range-swap-zero.md
+++ b/.changeset/fix-slider-range-swap-zero.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Slider: Fixed the range max thumb not swapping with the min thumb when the min thumb is at 0

--- a/packages/reshaped/src/components/Slider/SliderControlled.tsx
+++ b/packages/reshaped/src/components/Slider/SliderControlled.tsx
@@ -245,7 +245,8 @@ const SliderControlled: React.FC<T.ControlledProps & T.DefaultProps> = (props) =
 			let nextDraggingId = draggingId;
 
 			if (draggingId === minId && nextValue > maxValue) nextDraggingId = maxId;
-			if (draggingId === maxId && minValue && nextValue < minValue) nextDraggingId = minId;
+			if (draggingId === maxId && minValue !== undefined && nextValue < minValue)
+				nextDraggingId = minId;
 
 			if (nextDraggingId === minId) handleMinChange(nextValue);
 			if (nextDraggingId === maxId) handleMaxChange(nextValue);


### PR DESCRIPTION
## Problem
The thumb-overlap swap logic guards the max→min handoff with a truthy check on `minValue`:

```ts
if (draggingId === maxId && minValue && nextValue < minValue) nextDraggingId = minId;
```

When `minValue === 0` the `&& minValue` term is falsy, so the condition never runs. Dragging the **max** thumb below `0` therefore never hands off to the min thumb, allowing `maxValue < minValue` (crossed thumbs / inverted range). The symmetric min-side check (`draggingId === minId && nextValue > maxValue`) correctly omits the guard, confirming the asymmetry.

## Fix
```diff
-if (draggingId === maxId && minValue && nextValue < minValue) nextDraggingId = minId;
+if (draggingId === maxId && minValue !== undefined && nextValue < minValue)
+	nextDraggingId = minId;
```

## Before / After
- **Before:** with the min thumb at `0`, dragging the max thumb to a negative value leaves the thumbs crossed (`max < min`).
- **After:** the thumbs swap as expected, just like every other min value.

## How to test
1. Render a range `<Slider min={-10} max={10} defaultMinValue={0} defaultMaxValue={5} />`.
2. Drag the max thumb left, past `0`.
3. **Before:** no swap; range inverts. **After:** thumbs swap roles correctly.

Found during a full package bug review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_