### PR TITLE
fix(Slider): respect an uncontrolled default value of 0

### DIFF
--- a/.changeset/fix-slider-default-zero.md
+++ b/.changeset/fix-slider-default-zero.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Slider: Fixed an uncontrolled default value of 0 being ignored and falling back to min/max

--- a/packages/reshaped/src/components/Slider/SliderUncontrolled.tsx
+++ b/packages/reshaped/src/components/Slider/SliderUncontrolled.tsx
@@ -10,14 +10,16 @@ const normalizeValue = (value: number, min: number, max: number) =>
 
 const SliderUncontrolled: React.FC<T.UncontrolledProps & T.DefaultProps> = (props) => {
 	const { min, max, onChange, range } = props;
+	const defaultValue =
+		"defaultValue" in props && props.defaultValue !== undefined ? props.defaultValue : undefined;
 	const defaultMinValue =
-		("defaultMinValue" in props && props.defaultMinValue !== undefined && props.defaultMinValue) ||
-		("defaultValue" in props && props.defaultValue !== undefined && props.defaultValue) ||
-		min;
+		"defaultMinValue" in props && props.defaultMinValue !== undefined
+			? props.defaultMinValue
+			: (defaultValue ?? min);
 	const defaultMaxValue =
-		("defaultMaxValue" in props && props.defaultMaxValue !== undefined && props.defaultMaxValue) ||
-		("defaultValue" in props && props.defaultValue !== undefined && props.defaultValue) ||
-		(range ? max : min);
+		"defaultMaxValue" in props && props.defaultMaxValue !== undefined
+			? props.defaultMaxValue
+			: (defaultValue ?? (range ? max : min));
 	const [minValue, setMinValue] = React.useState(normalizeValue(defaultMinValue, min, max));
 	const [maxValue, setMaxValue] = React.useState(normalizeValue(defaultMaxValue, min, max));
 


### PR DESCRIPTION
## Problem
`SliderUncontrolled` resolved its initial values with `||` chains:

```ts
const defaultMinValue =
  ("defaultMinValue" in props && props.defaultMinValue !== undefined && props.defaultMinValue) ||
  ("defaultValue" in props && props.defaultValue !== undefined && props.defaultValue) ||
  min;
```

When the provided default is exactly `0`, the `&& props.defaultValue` term evaluates to `0` (falsy), so the chain falls through to `min`/`max`. So `<Slider min={-10} max={10} defaultValue={0} />` initializes at `-10` instead of `0`.

## Fix
Resolve with explicit `!== undefined` checks (and `??` so a `0` default is preserved):

```diff
-const defaultMinValue =
-	("defaultMinValue" in props && props.defaultMinValue !== undefined && props.defaultMinValue) ||
-	("defaultValue" in props && props.defaultValue !== undefined && props.defaultValue) ||
-	min;
-const defaultMaxValue =
-	("defaultMaxValue" in props && props.defaultMaxValue !== undefined && props.defaultMaxValue) ||
-	("defaultValue" in props && props.defaultValue !== undefined && props.defaultValue) ||
-	(range ? max : min);
+const defaultValue =
+	"defaultValue" in props && props.defaultValue !== undefined ? props.defaultValue : undefined;
+const defaultMinValue =
+	"defaultMinValue" in props && props.defaultMinValue !== undefined
+		? props.defaultMinValue
+		: (defaultValue ?? min);
+const defaultMaxValue =
+	"defaultMaxValue" in props && props.defaultMaxValue !== undefined
+		? props.defaultMaxValue
+		: (defaultValue ?? (range ? max : min));
```

## Before / After
```
defaultValue=0, min=-10:
  before initial value: -10   (ignores 0!)
  after  initial value: 0
```

## How to test
1. Render `<Slider min={-10} max={10} defaultValue={0} />`.
2. **Before:** the thumb starts at `-10`. **After:** it starts at `0`.

Found during a full package bug review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_