### PR TITLE
fix(useScrollLock): release the lock on unmount

### DIFF
--- a/.changeset/fix-usescrolllock-unmount.md
+++ b/.changeset/fix-usescrolllock-unmount.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+useScrollLock: Fixed the scroll lock not being released when the component unmounts while still locked

--- a/packages/reshaped/src/hooks/useScrollLock.ts
+++ b/packages/reshaped/src/hooks/useScrollLock.ts
@@ -24,6 +24,14 @@ const useScrollLock = (options?: {
 		unlockScrollRef.current = null;
 	}, []);
 
+	React.useEffect(
+		() => () => {
+			unlockScrollRef.current?.();
+			unlockScrollRef.current = null;
+		},
+		[]
+	);
+
 	return React.useMemo(
 		() => ({
 			scrollLocked: locked,


### PR DESCRIPTION
## Problem
`useScrollLock` stores the unlock function returned by `lockScroll` in `unlockScrollRef`, but there is **no effect cleanup** that releases it on unmount. If a component locks the scroll and then unmounts before calling `unlockScroll` — a route change while an overlay is open, an error boundary tearing the tree down, etc. — the global scroll lock (the body `overflow`/padding changes applied by `lockScroll`) is never reverted, leaving the page **permanently unscrollable**.

## Fix
```diff
 const handleUnlockScroll = React.useCallback(() => {
   unlockScrollRef.current?.({ callback: () => setLocked(false) });
   unlockScrollRef.current = null;
 }, []);
+
+// Release the lock if the component unmounts while still locked, otherwise the
+// global scroll lock (body padding/overflow changes) would leak permanently.
+React.useEffect(
+  () => () => {
+    unlockScrollRef.current?.();
+    unlockScrollRef.current = null;
+  },
+  []
+);
```

## Before / After
- **Before:** unmounting a component while its scroll lock is active leaves the page unscrollable.
- **After:** the lock is released automatically on unmount.

## How to test
1. Mount a component that locks scroll, then unmount it without explicitly unlocking (e.g. navigate away while an overlay is open).
2. **Before:** the page can no longer scroll. **After:** scrolling works.

Found during a full package bug review. Part of the scroll-lock cluster; the `@reshaped/utilities`-side fixes (lock ref-counting, scrollbar detection, StyleCache scoping, iOS guard) are submitted as separate PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_