### PR TITLE
fix(scroll): reference-count locks so stacked locks release correctly

### DIFF
--- a/.changeset/fix-lockscroll-refcount.md
+++ b/.changeset/fix-lockscroll-refcount.md
@@ -1,0 +1,5 @@
+---
+"@reshaped/utilities": patch
+---
+
+lockScroll: Fixed stacked/nested scroll locks releasing the scroll prematurely by reference-counting locks per container

--- a/packages/utilities/src/scroll/lock.ts
+++ b/packages/utilities/src/scroll/lock.ts
@@ -3,8 +3,7 @@ import { isIOS } from "@/platform";
 import lockSafariScroll from "./lockSafari";
 import lockStandardScroll from "./lockStandard";
 
-const lockCounts = new WeakMap<HTMLElement, number>();
-const lockResets = new WeakMap<HTMLElement, () => void>();
+const locks = new WeakMap<HTMLElement, { count: number; reset: () => void }>();
 
 export const lockScroll = (args?: {
 	containerEl?: HTMLElement | null;
@@ -19,17 +18,15 @@ export const lockScroll = (args?: {
 		document.documentElement;
 	const lockedDocumentScroll = container === document.documentElement;
 
-	const currentCount = lockCounts.get(container) ?? 0;
-
-	if (currentCount === 0) {
+	let lock = locks.get(container);
+	if (!lock) {
 		const reset =
-			isIOSLock && lockedDocumentScroll
-				? lockSafariScroll()
-				: lockStandardScroll({ container });
-		lockResets.set(container, reset);
+			isIOSLock && lockedDocumentScroll ? lockSafariScroll() : lockStandardScroll({ container });
+		lock = { count: 0, reset };
+		locks.set(container, lock);
 	}
 
-	lockCounts.set(container, currentCount + 1);
+	lock.count++;
 	args?.callback?.();
 
 	let released = false;
@@ -37,13 +34,9 @@ export const lockScroll = (args?: {
 		if (released) return;
 		released = true;
 
-		const nextCount = (lockCounts.get(container) ?? 1) - 1;
-		if (nextCount <= 0) {
-			lockCounts.delete(container);
-			lockResets.get(container)?.();
-			lockResets.delete(container);
-		} else {
-			lockCounts.set(container, nextCount);
+		if (--lock.count <= 0) {
+			lock.reset();
+			locks.delete(container);
 		}
 
 		unlockArgs?.callback?.();

--- a/packages/utilities/src/scroll/lock.ts
+++ b/packages/utilities/src/scroll/lock.ts
@@ -3,13 +3,15 @@ import { isIOS } from "@/platform";
 import lockSafariScroll from "./lockSafari";
 import lockStandardScroll from "./lockStandard";
 
+const lockCounts = new WeakMap<HTMLElement, number>();
+const lockResets = new WeakMap<HTMLElement, () => void>();
+
 export const lockScroll = (args?: {
 	containerEl?: HTMLElement | null;
 	originEl?: HTMLElement | null;
 	callback?: () => void;
 }) => {
 	const isIOSLock = isIOS();
-	let reset = () => {};
 
 	const container =
 		args?.containerEl ??
@@ -17,19 +19,33 @@ export const lockScroll = (args?: {
 		document.documentElement;
 	const lockedDocumentScroll = container === document.documentElement;
 
-	// Already locked so no need to lock again and trigger the callback
-	if (container.style.overflow === "hidden") return;
+	const currentCount = lockCounts.get(container) ?? 0;
 
-	if (isIOSLock && lockedDocumentScroll) {
-		reset = lockSafariScroll();
-	} else {
-		reset = lockStandardScroll({ container });
+	if (currentCount === 0) {
+		const reset =
+			isIOSLock && lockedDocumentScroll
+				? lockSafariScroll()
+				: lockStandardScroll({ container });
+		lockResets.set(container, reset);
 	}
 
+	lockCounts.set(container, currentCount + 1);
 	args?.callback?.();
 
-	return (args?: { callback?: () => void }) => {
-		reset();
-		args?.callback?.();
+	let released = false;
+	return (unlockArgs?: { callback?: () => void }) => {
+		if (released) return;
+		released = true;
+
+		const nextCount = (lockCounts.get(container) ?? 1) - 1;
+		if (nextCount <= 0) {
+			lockCounts.delete(container);
+			lockResets.get(container)?.();
+			lockResets.delete(container);
+		} else {
+			lockCounts.set(container, nextCount);
+		}
+
+		unlockArgs?.callback?.();
 	};
 };

--- a/packages/utilities/src/scroll/tests/lock.test.ts
+++ b/packages/utilities/src/scroll/tests/lock.test.ts
@@ -73,14 +73,30 @@ describe("scroll/lockScroll", () => {
 		expect(scrollableContainer.style.overflow).toBe("auto");
 	});
 
-	test("unlocks after multiple locks", () => {
+	test("keeps scroll locked until every stacked lock is released", () => {
 		const unlock1 = lockScroll({});
 		const unlock2 = lockScroll({});
 
 		expect(document.documentElement.style.overflow).toBe("hidden");
 
+		// The first release must not unlock while a second lock is still held
 		unlock1?.();
+		expect(document.documentElement.style.overflow).toBe("hidden");
+
+		// Only the last release actually unlocks the container
+		unlock2?.();
 		expect(document.documentElement.style.overflow).toBe("");
+	});
+
+	test("ignores repeated calls to the same unlock", () => {
+		const unlock1 = lockScroll({});
+		const unlock2 = lockScroll({});
+
+		// Calling the first unlock twice must not decrement the count for unlock2
+		unlock1?.();
+		unlock1?.();
+
+		expect(document.documentElement.style.overflow).toBe("hidden");
 
 		unlock2?.();
 		expect(document.documentElement.style.overflow).toBe("");
@@ -89,9 +105,11 @@ describe("scroll/lockScroll", () => {
 	test("calls lock callback immediately", () => {
 		const lockCb = vi.fn();
 
-		lockScroll({ callback: lockCb });
+		const unlock = lockScroll({ callback: lockCb });
 
 		expect(lockCb).toHaveBeenCalledTimes(1);
+
+		unlock?.();
 	});
 
 	test("calls unlock callback when unlocking", () => {


### PR DESCRIPTION
## Problem
`lockScroll` short-circuited when the container was already locked:

```ts
// Already locked so no need to lock again and trigger the callback
if (container.style.overflow === "hidden") return;
```

This returns `undefined`, so a **second** locker (e.g. a modal opening a dropdown, or two modals both locking the document) gets no unlock function and its `callback` never fires. And because there's no tracking of who holds the lock, **releasing the first lock restores the scroll while the second is still open** — the page becomes scrollable under an open overlay, and the second overlay has no way to unlock.

## Fix
Reference-count active locks per container (via `WeakMap`): apply the style changes only for the first lock, restore only when the last lock is released, and always return a valid, idempotent unlock function.

```ts
const lockCounts = new WeakMap<HTMLElement, number>();
const lockResets = new WeakMap<HTMLElement, () => void>();
// ...
if (currentCount === 0) { /* apply lock, store reset */ }
lockCounts.set(container, currentCount + 1);
// unlock(): decrement; when it hits 0, run the stored reset
```

Behavioural note: `lockScroll` now **always** returns an unlock function (previously it could return `undefined`). Callers that did `unlock?.()` are unaffected.

## Verification
Logic simulated:
```
after 2 locks: applied=1 reset=0   (styles applied once)
after unlock A: reset=0            (B still open -> still locked)
after unlock B: reset=1            (last unlock -> restored)
double unlock A: reset=1           (idempotent)
```
- `tsc --noEmit` (utilities) → 0 errors. `oxlint` → clean.

## How to test
1. Open a Modal, then from within it open a Dropdown/another Modal (both lock the document).
2. Close them in either order.
3. **Before:** closing the first re-enables page scroll while the second is still open; the second may never restore scroll. **After:** scroll stays locked until the last overlay closes, then restores.

Found during a full package bug review. Complementary to the StyleCache-scoping and iOS-guard PRs in the same cluster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_