### PR TITLE
fix(scroll): scope StyleCache.reset to the locked element

### DIFF
--- a/.changeset/fix-stylecache-scoped-reset.md
+++ b/.changeset/fix-stylecache-scoped-reset.md
@@ -1,0 +1,5 @@
+---
+"@reshaped/utilities": patch
+---
+
+StyleCache: `reset()` used to restore and clear the entire cache, which let one scroll lock wipe the saved styles of another still-active lock. It now takes a required element and restores only that one. `set()` is also a no-op when the element is already cached, so locking an already-locked element keeps its original styles intact.

--- a/packages/utilities/src/css/StyleCache.ts
+++ b/packages/utilities/src/css/StyleCache.ts
@@ -1,26 +1,28 @@
 type Styles = Record<string, string>;
 
 class StyleCache {
-	cache: Map<HTMLElement, Record<string, string>> = new Map();
+	cache: Map<HTMLElement, Styles> = new Map();
 
 	set = (el: HTMLElement, styles: Styles) => {
-		const originalStyles: Styles = {};
-		const cachedStyles = this.cache.get(el);
+		// Already cached (locked) — keep the originals captured the first time and
+		// don't reapply, so locking an element that's already locked is a no-op.
+		if (this.cache.has(el)) return;
 
+		const originalStyles: Styles = {};
 		Object.keys(styles).forEach((key) => {
 			originalStyles[key] = el.style.getPropertyValue(key);
 		});
 
-		this.cache.set(el, { ...originalStyles, ...cachedStyles });
+		this.cache.set(el, originalStyles);
 		Object.assign(el.style, styles);
 	};
 
-	reset = () => {
-		for (const [el, styles] of this.cache.entries()) {
-			Object.assign(el.style, styles);
-		}
+	reset = (el: HTMLElement) => {
+		const styles = this.cache.get(el);
+		if (!styles) return;
 
-		this.cache.clear();
+		Object.assign(el.style, styles);
+		this.cache.delete(el);
 	};
 }
 

--- a/packages/utilities/src/css/tests/StyleCache.test.ts
+++ b/packages/utilities/src/css/tests/StyleCache.test.ts
@@ -19,24 +19,28 @@ describe("css/StyleCache", () => {
 		expect(el.style.color).toBe("blue");
 		expect(el.style.overflow).toBe("hidden");
 
-		styleCache.reset();
+		styleCache.reset(el);
 
 		expect(el.style.color).toBe("red");
 		expect(el.style.overflow).toBe("visible");
 	});
 
-	test("preserves original styles across multiple set calls", () => {
+	test("ignores repeated set calls on an already-cached element", () => {
 		const el = document.createElement("div");
 		el.style.color = "red";
 
 		styleCache.set(el, { color: "blue" });
+		// The element is already cached, so this is a no-op (style stays "blue")
 		styleCache.set(el, { color: "green" });
-		styleCache.reset();
+
+		expect(el.style.color).toBe("blue");
+
+		styleCache.reset(el);
 
 		expect(el.style.color).toBe("red");
 	});
 
-	test("handles multiple elements", () => {
+	test("reset only affects the given element", () => {
 		const el1 = document.createElement("div");
 		const el2 = document.createElement("div");
 		el1.style.color = "red";
@@ -44,18 +48,34 @@ describe("css/StyleCache", () => {
 
 		styleCache.set(el1, { color: "green" });
 		styleCache.set(el2, { color: "yellow" });
-		styleCache.reset();
 
+		styleCache.reset(el1);
+
+		// el1 is restored, el2 stays locked
 		expect(el1.style.color).toBe("red");
+		expect(el2.style.color).toBe("yellow");
+		expect(styleCache.cache.has(el2)).toBe(true);
+
+		styleCache.reset(el2);
+
 		expect(el2.style.color).toBe("blue");
 	});
 
-	test("clears cache after reset", () => {
+	test("reset is a no-op for an element that was never cached", () => {
+		const el = document.createElement("div");
+		el.style.color = "red";
+
+		styleCache.reset(el);
+
+		expect(el.style.color).toBe("red");
+	});
+
+	test("removes the element from the cache after reset", () => {
 		const el = document.createElement("div");
 		el.style.color = "red";
 
 		styleCache.set(el, { color: "blue" });
-		styleCache.reset();
+		styleCache.reset(el);
 
 		expect(styleCache.cache.size).toBe(0);
 	});

--- a/packages/utilities/src/scroll/lockSafari.ts
+++ b/packages/utilities/src/scroll/lockSafari.ts
@@ -17,7 +17,7 @@ const lockSafariScroll = () => {
 	});
 
 	return () => {
-		styleCache.reset();
+		styleCache.reset(document.body);
 		window.scrollTo({ top: scrollY, left: scrollX, behavior: "instant" });
 	};
 };

--- a/packages/utilities/src/scroll/lockStandard.ts
+++ b/packages/utilities/src/scroll/lockStandard.ts
@@ -7,19 +7,19 @@ const lockStandardScroll = (args: { container: HTMLElement }) => {
 	const { container } = args;
 	const rect = container.getBoundingClientRect();
 	const isOverflowing = rect.left + rect.right < window.innerWidth;
-
-	styleCache.set(container, { overflow: "hidden" });
+	const styles: Record<string, string> = { overflow: "hidden" };
 
 	if (isOverflowing) {
 		if (CSS.supports("scrollbar-gutter", "stable")) {
-			styleCache.set(container, { scrollbarGutter: "stable" });
+			styles.scrollbarGutter = "stable";
 		} else {
-			const scrollBarWidth = getScrollbarWidth();
-			styleCache.set(container, { paddingRight: `${scrollBarWidth}px` });
+			styles.paddingRight = `${getScrollbarWidth()}px`;
 		}
 	}
 
-	return () => styleCache.reset();
+	styleCache.set(container, styles);
+
+	return () => styleCache.reset(container);
 };
 
 export default lockStandardScroll;

--- a/packages/utilities/src/scroll/tests/lock.test.ts
+++ b/packages/utilities/src/scroll/tests/lock.test.ts
@@ -86,6 +86,37 @@ describe("scroll/lockScroll", () => {
 		expect(document.documentElement.style.overflow).toBe("");
 	});
 
+	test("unlocking one container does not affect another locked container", () => {
+		const a = document.createElement("div");
+		a.style.overflow = "auto";
+		a.style.height = "100px";
+		document.body.appendChild(a);
+
+		const b = document.createElement("div");
+		b.style.overflow = "scroll";
+		b.style.height = "100px";
+		document.body.appendChild(b);
+
+		const unlockA = lockScroll({ containerEl: a });
+		const unlockB = lockScroll({ containerEl: b });
+
+		expect(a.style.overflow).toBe("hidden");
+		expect(b.style.overflow).toBe("hidden");
+
+		unlockA?.();
+
+		// B shares the module-level StyleCache with A, but must stay locked
+		expect(a.style.overflow).toBe("auto");
+		expect(b.style.overflow).toBe("hidden");
+
+		unlockB?.();
+
+		expect(b.style.overflow).toBe("scroll");
+
+		document.body.removeChild(a);
+		document.body.removeChild(b);
+	});
+
 	test("calls lock callback immediately", () => {
 		const lockCb = vi.fn();
 


### PR DESCRIPTION
## Problem
`StyleCache.reset()` restored **and cleared the entire cache**, regardless of which element a given lock owned:

```ts
reset = () => {
  for (const [el, styles] of this.cache.entries()) Object.assign(el.style, styles);
  this.cache.clear();
};
```

`lockStandardScroll` and `lockSafariScroll` each use a **module-level** `StyleCache` shared across all their calls. So when two **different** elements are locked at once — e.g. an `Overlay` locking one container (`useScrollLock({ containerRef })`) while a `ContextMenu` locks another (`useScrollLock({ originRef })`) — restoring one lock wipes the saved originals of the other still-active lock. The survivor can no longer restore its styles (scroll lock leaks or releases early).

Note this is the **cross-container** case. The per-container guard in `lockScroll` (`if (container.style.overflow === "hidden") return`) only blocks re-locking the *same* element, so two different elements both land in the shared cache.

## Fix
Make `StyleCache` a per-element lock registry:

- **`reset(el)` is now required and scoped** — it restores and removes only that element's entry, never touching other active locks.
- **`set(el, styles)` is a no-op when the element is already cached** — locking an already-locked element keeps the originals captured the first time, instead of merging.
- **`lockStandardScroll` builds its styles into one object and calls `set()` once** (overflow + optional `scrollbar-gutter`/`paddingRight` together), so all keys are captured atomically — required now that `set()` is idempotent per element.
- `lockSafariScroll` already does a single `set()`; its unlock now calls `reset(document.body)`.

```ts
reset = (el: HTMLElement) => {
  const styles = this.cache.get(el);
  if (!styles) return;
  Object.assign(el.style, styles);
  this.cache.delete(el);
};
```

### API note
`reset()` now requires an element (the global no-arg form is removed). The only callers are the two lock modules; both pass the element they locked.

## Verification
- `tsc --noEmit` → 0 errors. `oxlint` → clean.
- `StyleCache.test.ts` updated for the new semantics (scoped reset, idempotent set, no-op reset for uncached element).
- Added an integration test in `scroll/tests/lock.test.ts`: **unlocking one container does not affect another locked container** — confirmed it **fails against the old global-wipe `reset()`** and passes with the scoped fix.
- Full css + scroll suites green (13 tests).

## How to test
1. Lock scroll on two different containers (e.g. an Overlay container and a ContextMenu's scrollable region), then unlock one.
2. **Before:** the still-locked container loses its saved styles and can't restore on its own unlock. **After:** each unlock restores only its own element.

Found during a full package bug review. Part of the scroll-lock cluster.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_