### PR TITLE
fix(scroll): guard against re-locking iOS Safari scroll while locked

### DIFF
--- a/.changeset/fix-locksafari-nested-guard.md
+++ b/.changeset/fix-locksafari-nested-guard.md
@@ -1,0 +1,5 @@
+---
+"@reshaped/utilities": patch
+---
+
+lockScroll: Fixed iOS Safari scroll being stuck (body left position: fixed) after nested overlays locked the document

--- a/packages/utilities/src/scroll/lockSafari.ts
+++ b/packages/utilities/src/scroll/lockSafari.ts
@@ -3,6 +3,10 @@ import { StyleCache } from "@/css";
 const styleCache = new StyleCache();
 
 const lockSafariScroll = () => {
+	if (document.body.style.position === "fixed") {
+		return () => {};
+	}
+
 	const viewport = window.visualViewport;
 	const offsetLeft = viewport?.offsetLeft || 0;
 	const offsetTop = viewport?.offsetTop || 0;


### PR DESCRIPTION
## Problem
On iOS the document scroll lock is applied to `document.body` (`position: fixed`), but the "already locked" guard in `lockScroll` checks `document.documentElement.style.overflow`. So on iOS a **nested** lock (e.g. a modal opening a dropdown) is not recognised as already-locked and re-enters `lockSafariScroll`. At that point:

- `window.scrollX/scrollY` read `0` (the body is already fixed),
- `styleCache.set(document.body, …)` overwrites the cached **original** `top`/`left`/`position` with the already-fixed values.

When the outer lock is released it restores the body to `position: fixed`, leaving the **page permanently unscrollable** until reload.

## Fix
Bail out with a no-op unlock when the body is already fixed, so the second lock doesn't re-capture the zeroed scroll position or clobber the cache:

```diff
 const lockSafariScroll = () => {
+	// Already locked (e.g. a nested overlay): the body is fixed and window.scrollX/Y
+	// now read 0, so re-capturing here would overwrite the saved originals with the
+	// already-fixed values and lose the real scroll position. Return a no-op unlock.
+	if (document.body.style.position === "fixed") {
+		return () => {};
+	}
+
 	const viewport = window.visualViewport;
```

## Verification
- `tsc --noEmit` (utilities) → 0 errors. `oxlint` → clean.

## How to test
1. On iOS Safari, open a Modal (locks the document), then open a nested overlay from inside it, and close them.
2. **Before:** the page is stuck (body remains `position: fixed`) and scroll position is lost. **After:** scroll is restored correctly to the original position.

Found during a full package bug review. Complementary to the lock ref-counting PR (which prevents the double-entry at the `lockScroll` level); this adds defense-in-depth inside `lockSafariScroll` itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01We9NqptZjfbvXRL4hE1xri)_