### PR TITLE
fix(theming): prevent reference errors on CJS require call

### DIFF
--- a/.changeset/orange-bugs-fold.md
+++ b/.changeset/orange-bugs-fold.md
@@ -1,0 +1,5 @@
+---
+"@reshaped/theming": patch
+---
+
+Fixed cli/run undefined CJS require call in an ES module context.

--- a/packages/theming/src/cli/run.ts
+++ b/packages/theming/src/cli/run.ts
@@ -1,12 +1,14 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { createRequire } from "node:module";
 import chalk from "chalk";
 import { Command } from "commander";
 
 import defaultConfig from "./reshaped.config";
 import { addTheme, addThemeFragment } from "./index";
 
+const require = createRequire(import.meta.url);
 const program = new Command();
 
 const importJSConfig = (configPath: string) => {


### PR DESCRIPTION
## Summary

Calling commonjs `require` in an ES modules produce a reference error. 

## Related Issue

Fixes https://github.com/reshaped-ui/reshaped/issues/644

## Notes for Reviewers

Went the "simplest" path with `createRequire`. We could also use a dynamic `import()` but that would produce more changes (async).
