### PR TITLE
View: add center keyword for insetInline and insetBlock

### DIFF
--- a/.changeset/view-inset-center.md
+++ b/.changeset/view-inset-center.md
@@ -1,0 +1,5 @@
+---
+"reshaped": minor
+---
+
+View: Added insetInline and insetBlock props with support for the "center" keyword value for centering absolutely positioned elements

--- a/packages/reshaped/src/components/View/View.tsx
+++ b/packages/reshaped/src/components/View/View.tsx
@@ -98,6 +98,8 @@ const View = <As extends keyof React.JSX.IntrinsicElements = "div">(props: T.Pro
 		insetBottom,
 		insetStart,
 		insetEnd,
+		insetInline,
+		insetBlock,
 		zIndex,
 
 		/**
@@ -127,6 +129,8 @@ const View = <As extends keyof React.JSX.IntrinsicElements = "div">(props: T.Pro
 		insetBottom,
 		insetStart,
 		insetEnd,
+		insetInline,
+		insetBlock,
 		bleed,
 		width,
 		height,

--- a/packages/reshaped/src/components/View/View.types.ts
+++ b/packages/reshaped/src/components/View/View.types.ts
@@ -111,6 +111,10 @@ export type Props<TagName extends keyof React.JSX.IntrinsicElements | void = voi
 	insetTop?: G.Responsive<TStyles.Inset>;
 	/** Inset bottom, base unit token number multiplier when used as a number */
 	insetBottom?: G.Responsive<TStyles.Inset>;
+	/** Inset inline, base unit token number multiplier when used as a number, "center" centers on the inline axis */
+	insetInline?: G.Responsive<TStyles.InsetAxis>;
+	/** Inset block, base unit token number multiplier when used as a number, "center" centers on the block axis */
+	insetBlock?: G.Responsive<TStyles.InsetAxis>;
 	/** z-index style, based on the z-index tokens when used as a string */
 	zIndex?: TStyles.ZIndex;
 	/** Shadow style, based on the shadow tokens */

--- a/packages/reshaped/src/components/View/tests/View.stories.tsx
+++ b/packages/reshaped/src/components/View/tests/View.stories.tsx
@@ -1005,6 +1005,67 @@ export const inset = {
 				</View>
 			</Example.Item>
 
+			<Example.Item title="insetInline: 4">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetInline={4}
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
+			<Example.Item title="insetBlock: 4">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetBlock={4}
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
+			<Example.Item title="insetInline: center">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetInline="center"
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
+			<Example.Item title="insetBlock: center">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetBlock="center"
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
+			<Example.Item title="insetInline: center, insetBlock: center">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetInline="center"
+						insetBlock="center"
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
 			<Example.Item title="responsive, [s] insetBottom: 4 [m+] insetEnd: 4">
 				<View backgroundColor="neutral-faded" width={25} height={25}>
 					<View
@@ -1012,6 +1073,18 @@ export const inset = {
 						position="absolute"
 						insetBottom={{ s: 4, m: "auto" }}
 						insetEnd={{ s: "auto", m: 4 }}
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
+			<Example.Item title="responsive, [s] insetInline: center [m+] insetInline: 4">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						insetInline={{ s: "center", m: 4 }}
 						height={10}
 						width={10}
 					/>

--- a/packages/reshaped/src/styles/resolvers/inset/__snapshots__/index.test.ts.snap
+++ b/packages/reshaped/src/styles/resolvers/inset/__snapshots__/index.test.ts.snap
@@ -30,22 +30,72 @@ exports[`Styles/Inset > handles undefined value 1`] = `{}`;
 
 exports[`Styles/Inset/Block > handles 0 value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--block-unit_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-block-s": 0,
   },
 }
 `;
 
+exports[`Styles/Inset/Block > handles center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--block-center_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-block-s": "center",
+  },
+}
+`;
+
 exports[`Styles/Inset/Block > handles positive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--block-unit_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-block-s": 4,
   },
 }
 `;
 
+exports[`Styles/Inset/Block > handles responsive center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--block-center_31d553",
+      "_--block-unit--m_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-block-m": 4,
+    "--rs-inset-block-s": "center",
+  },
+}
+`;
+
 exports[`Styles/Inset/Block > handles responsive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--block-unit_31d553",
+      "_--block-unit--m_31d553",
+      "_--block-unit--l_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-block-l": 2,
     "--rs-inset-block-m": 0,
@@ -114,22 +164,72 @@ exports[`Styles/Inset/End > handles undefined value 1`] = `{}`;
 
 exports[`Styles/Inset/Inline > handles 0 value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-inline-s": 0,
   },
 }
 `;
 
+exports[`Styles/Inset/Inline > handles center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-center_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-inline-s": "center",
+  },
+}
+`;
+
 exports[`Styles/Inset/Inline > handles positive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-inline-s": 4,
   },
 }
 `;
 
+exports[`Styles/Inset/Inline > handles responsive center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-center_31d553",
+      "_--inline-unit--m_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-inline-m": 4,
+    "--rs-inset-inline-s": "center",
+  },
+}
+`;
+
 exports[`Styles/Inset/Inline > handles responsive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+      "_--inline-unit--m_31d553",
+      "_--inline-unit--l_31d553",
+    ],
+  ],
   "variables": {
     "--rs-inset-inline-l": 2,
     "--rs-inset-inline-m": 0,

--- a/packages/reshaped/src/styles/resolvers/inset/index.test.ts
+++ b/packages/reshaped/src/styles/resolvers/inset/index.test.ts
@@ -112,8 +112,16 @@ describe("Styles/Inset/Inline", () => {
 		expect(insetInline()).toMatchSnapshot();
 	});
 
+	test("handles center value", () => {
+		expect(insetInline("center")).toMatchSnapshot();
+	});
+
 	test("handles responsive value", async () => {
 		expect(insetInline({ s: 4, m: 0, l: 2 })).toMatchSnapshot();
+	});
+
+	test("handles responsive center value", async () => {
+		expect(insetInline({ s: "center", m: 4 })).toMatchSnapshot();
 	});
 });
 
@@ -130,7 +138,15 @@ describe("Styles/Inset/Block", () => {
 		expect(insetBlock()).toMatchSnapshot();
 	});
 
+	test("handles center value", () => {
+		expect(insetBlock("center")).toMatchSnapshot();
+	});
+
 	test("handles responsive value", async () => {
 		expect(insetBlock({ s: 4, m: 0, l: 2 })).toMatchSnapshot();
+	});
+
+	test("handles responsive center value", async () => {
+		expect(insetBlock({ s: "center", m: 4 })).toMatchSnapshot();
 	});
 });

--- a/packages/reshaped/src/styles/resolvers/inset/index.ts
+++ b/packages/reshaped/src/styles/resolvers/inset/index.ts
@@ -1,5 +1,6 @@
-import { responsiveVariables } from "@/utilities/props";
+import { responsiveClassNames, responsiveVariables } from "@/utilities/props";
 import * as T from "@/styles/types";
+import s from "./inset.module.css";
 import "./inset.css";
 
 const inset: T.StyleResolver<T.Inset> = (value) => {
@@ -27,14 +28,34 @@ export const insetEnd: T.StyleResolver<T.Inset> = (value) => {
 	return { variables: responsiveVariables("--rs-inset-end", value) };
 };
 
-export const insetInline: T.StyleResolver<T.Inset> = (value) => {
+export const insetInline: T.StyleResolver<T.InsetAxis> = (value) => {
 	if (value === undefined) return {};
-	return { variables: responsiveVariables("--rs-inset-inline", value) };
+	const classNames = responsiveClassNames(
+		s,
+		(value) => (value === "center" ? "--inline-center" : "--inline-unit"),
+		value,
+		{ excludeValueFromClassName: true }
+	);
+
+	return {
+		classNames: [s.root, classNames],
+		variables: responsiveVariables("--rs-inset-inline", value),
+	};
 };
 
-export const insetBlock: T.StyleResolver<T.Inset> = (value) => {
+export const insetBlock: T.StyleResolver<T.InsetAxis> = (value) => {
 	if (value === undefined) return {};
-	return { variables: responsiveVariables("--rs-inset-block", value) };
+	const classNames = responsiveClassNames(
+		s,
+		(value) => (value === "center" ? "--block-center" : "--block-unit"),
+		value,
+		{ excludeValueFromClassName: true }
+	);
+
+	return {
+		classNames: [s.root, classNames],
+		variables: responsiveVariables("--rs-inset-block", value),
+	};
 };
 
 export default inset;

--- a/packages/reshaped/src/styles/resolvers/inset/inset.css
+++ b/packages/reshaped/src/styles/resolvers/inset/inset.css
@@ -4,18 +4,6 @@
 	inset: calc(var(--rs-inset) * var(--rs-unit-x1));
 }
 
-@responsive [style*="--rs-inset-inline-"] {
-	@variable --rs-inset-inline 0;
-
-	inset-inline: calc(var(--rs-inset-inline) * var(--rs-unit-x1));
-}
-
-@responsive [style*="--rs-inset-block-"] {
-	@variable --rs-inset-block 0;
-
-	inset-block: calc(var(--rs-inset-block) * var(--rs-unit-x1));
-}
-
 @responsive [style*="--rs-inset-end-"] {
 	@variable --rs-inset-end 0;
 

--- a/packages/reshaped/src/styles/resolvers/inset/inset.module.css
+++ b/packages/reshaped/src/styles/resolvers/inset/inset.module.css
@@ -1,0 +1,57 @@
+/* stylelint-disable plugin/browser-compat -- graceful degradation, var() fallbacks keep centering working without @property */
+@property --rs-inset-translate-x {
+	syntax: "<length-percentage>";
+	initial-value: 0;
+	inherits: false;
+}
+
+@property --rs-inset-translate-y {
+	syntax: "<length-percentage>";
+	initial-value: 0;
+	inherits: false;
+}
+/* stylelint-enable plugin/browser-compat */
+
+@responsive .root[style*="--rs-inset-inline-"] {
+	@variable --rs-inset-inline 0;
+}
+
+@responsive .root[style*="--rs-inset-block-"] {
+	@variable --rs-inset-block 0;
+}
+
+@responsive .--inline {
+	@value center {
+		/* Physical properties keep centering direction-agnostic in RTL */
+		left: 50%;
+		right: auto;
+
+		--rs-inset-translate-x: -50%;
+
+		translate: var(--rs-inset-translate-x, 0) var(--rs-inset-translate-y, 0);
+	}
+
+	@value unit {
+		--rs-inset-translate-x: 0;
+
+		inset-inline: calc(var(--rs-inset-inline) * var(--rs-unit-x1));
+	}
+}
+
+@responsive .--block {
+	@value center {
+		/* Physical properties keep centering direction-agnostic in RTL */
+		top: 50%;
+		bottom: auto;
+
+		--rs-inset-translate-y: -50%;
+
+		translate: var(--rs-inset-translate-x, 0) var(--rs-inset-translate-y, 0);
+	}
+
+	@value unit {
+		--rs-inset-translate-y: 0;
+
+		inset-block: calc(var(--rs-inset-block) * var(--rs-unit-x1));
+	}
+}

--- a/packages/reshaped/src/styles/resolvers/zIndex/index.ts
+++ b/packages/reshaped/src/styles/resolvers/zIndex/index.ts
@@ -1,9 +1,13 @@
 import type React from "react";
+import type { ClassName } from "@reshaped/utilities";
 
 import * as T from "@/styles/types";
 import "./zIndex.css";
 
-const zIndex: (value?: T.ZIndex) => { variables?: React.CSSProperties } = (value) => {
+const zIndex: (value?: T.ZIndex) => {
+	variables?: React.CSSProperties;
+	classNames?: ClassName;
+} = (value) => {
 	if (value === undefined) return {};
 
 	return {

--- a/packages/reshaped/src/styles/types.ts
+++ b/packages/reshaped/src/styles/types.ts
@@ -11,6 +11,7 @@ type Size = Literal | Unit;
 export type Margin = Unit;
 export type Padding = Unit;
 export type Inset = Unit | "auto";
+export type InsetAxis = Inset | "center";
 export type AspectRatio = number;
 export type Bleed = Unit;
 
@@ -94,8 +95,8 @@ export type Mixin = {
 	insetBottom?: G.Responsive<Inset>;
 	insetStart?: G.Responsive<Inset>;
 	insetEnd?: G.Responsive<Inset>;
-	insetInline?: G.Responsive<Inset>;
-	insetBlock?: G.Responsive<Inset>;
+	insetInline?: G.Responsive<InsetAxis>;
+	insetBlock?: G.Responsive<InsetAxis>;
 
 	padding?: G.Responsive<Padding>;
 	paddingTop?: G.Responsive<Padding>;


### PR DESCRIPTION
## Summary

- Adds `insetInline` and `insetBlock` props to `View` (the style mixin already had resolvers for them, but they weren't exposed on the component)
- Both props support a new `"center"` keyword value alongside unit numbers and `"auto"`. `insetInline="center"` centers an absolutely positioned element on the inline axis, `insetBlock="center"` on the block axis, and setting both centers it fully
- Centering is implemented as `left: 50%` (or `top: 50%`) plus a `translate: -50%` on the matching axis. The two axes compose through `--rs-inset-translate-x/y` custom properties (registered with `@property … inherits: false` so they don't leak into nested centered elements), so using both keywords resolves to `translate: -50% -50%`
- The inline/block resolvers moved from the plain attribute-selector CSS to the classname-gated pattern already used by the `width` resolver (`@value center` / `@value unit`), so responsive values like `{ s: "center", m: 4 }` correctly switch between centering and unit insets per viewport, with the translate reset on unit viewports
- Physical properties (`left`/`top`) are used for the center value on purpose: centering is symmetric, so this keeps it direction-agnostic and RTL needs no extra handling
- Also fixes the `zIndex` resolver's return type missing `classNames`, which broke `tsc` on `resolveMixin` since the last commit on main

## Related Issue

N/A

## Screenshots / Recordings

Verified in a real browser (Storybook + Playwright) by measuring bounding boxes against the container center across LTR/RTL and s/m viewports:

| Case | LTR desktop | RTL desktop | LTR mobile | RTL mobile |
|---|---|---|---|---|
| `insetInline="center"` | centered x | centered x | centered x | centered x |
| `insetBlock="center"` | centered y | centered y | centered y | centered y |
| both | centered x+y | centered x+y | centered x+y | centered x+y |
| `insetInline={{ s: "center", m: 4 }}` | 16px insets | 16px insets | centered x | centered x |

All centered cases measured a 0.0px offset from the container center. New story examples were added under the View `inset` story.

## Notes for Reviewers

- `inset.css` keeps the attribute-selector rules for `inset`, `insetTop/Bottom/Start/End`; only the inline/block rules moved into `inset.module.css` since they now need value-based classnames
- The `var(--rs-inset-translate-x, 0)` fallbacks keep centering working in browsers without `@property` support (with the minor caveat that the custom properties become inheritable there)
- Snapshot changes for `insetInline`/`insetBlock` resolvers reflect the added classnames; all 181 unit tests pass, `tsc` (esm and stories configs) and stylelint/oxlint are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6V36sEHRNKzN996awyGmG

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6V36sEHRNKzN996awyGmG)_