### PR TITLE
fix(Button): keep group border above highlighted buttons

### DIFF
--- a/.changeset/fix-button-group-border-zindex.md
+++ b/.changeset/fix-button-group-border-zindex.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Button.Group: Fixed the outline group border being masked by a highlighted button when the highlight color is fully opaque, by rendering the group border above highlighted buttons in the stacking context

--- a/packages/reshaped/src/components/Button/Button.module.css
+++ b/packages/reshaped/src/components/Button/Button.module.css
@@ -384,7 +384,9 @@
 			content: "";
 			position: absolute;
 			pointer-events: none;
-			z-index: var(--rs-z-index-relative);
+
+			/* Keep the group border above highlighted buttons so a plain highlight color doesn't mask it */
+			z-index: calc(var(--rs-z-index-relative) + 1);
 			inset: 0;
 			border: 1px solid var(--rs-color-border-neutral);
 			border-radius: 6px;
@@ -396,7 +398,7 @@
 			inset: 1px;
 			pointer-events: none;
 			border-radius: inherit;
-			z-index: var(--rs-z-index-relative);
+			z-index: calc(var(--rs-z-index-relative) + 1);
 		}
 	}
 }

--- a/packages/reshaped/src/components/Button/tests/Button.stories.tsx
+++ b/packages/reshaped/src/components/Button/tests/Button.stories.tsx
@@ -756,6 +756,38 @@ export const group: StoryObj = {
 				</View>
 			</Example.Item>
 
+			<Example.Item title="variant: outline, highlighted">
+				<View gap={2} align="start">
+					{(["neutral", "primary", "critical", "positive"] as const).map((color) => (
+						<Button.Group key={color}>
+							<Button color={color} variant="outline">
+								One
+							</Button>
+							<Button color={color} variant="outline" highlighted>
+								Two
+							</Button>
+							<Button color={color} variant="outline">
+								Three
+							</Button>
+						</Button.Group>
+					))}
+					{/* Plain (opaque) highlight color should not mask the group border – see #649 */}
+					<Button.Group
+						attributes={{
+							style: {
+								["--rs-color-background-neutral-highlighted-faded" as string]: "#d4d4d4",
+							},
+						}}
+					>
+						<Button variant="outline">One</Button>
+						<Button variant="outline" highlighted>
+							Two
+						</Button>
+						<Button variant="outline">Three</Button>
+					</Button.Group>
+				</View>
+			</Example.Item>
+
 			<Example.Item title="variant: ghost">
 				<View gap={2} align="start">
 					{(["neutral", "primary", "critical", "positive"] as const).map((color) => (


### PR DESCRIPTION
## Summary

The `Button.Group` outline border (rendered via the group's `::before` pseudo-element) and a highlighted button's `--highlighted` layer both used `--rs-z-index-relative` within the same stacking context. Because the button comes later in DOM order, it painted over the border. When the highlight color is semi-transparent this goes unnoticed, but with a **fully opaque** highlight color (common when theming) the highlighted button masks the group border.

The fix raises the group's border/shadow pseudo-elements (`::before`/`::after`) one level above the highlighted button (`calc(var(--rs-z-index-relative) + 1)`), so the group border always renders on top regardless of highlight color opacity. The highlighted button still stays above its neighbouring buttons; only the thin group frame is lifted above it.

## Related Issue

Fixes #649

## Screenshots / Recordings

Verified in Storybook (`Components/Button` → `group` → new "variant: outline, highlighted" example) using an opaque `#d4d4d4` highlight override. Border shown in red to make the stacking order unambiguous:

- **Before:** the group border is broken/masked across the highlighted middle button.
- **After:** the group border is continuous across the highlighted middle button.

## Notes for Reviewers

- Change is CSS-only in `Button.module.css`; the highlighted button keeps `--rs-z-index-relative` so its ordering relative to sibling buttons is unchanged.
- Added a `variant: outline, highlighted` case to the `group` story, including a group that overrides `--rs-color-background-neutral-highlighted-faded` to an opaque grey to guard against regressions.
- Added a changeset (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QGUrWA93vCuPkGwTYsg55

---
_Generated by [Claude Code](https://claude.ai/code/session_018QGUrWA93vCuPkGwTYsg55)_