### PR TITLE
feat(View): support inset="center" for both-axis centering

### DIFF
--- a/.changeset/view-inset-center.md
+++ b/.changeset/view-inset-center.md
@@ -2,4 +2,4 @@
 "reshaped": minor
 ---
 
-View: Added insetInline and insetBlock props with support for the "center" keyword value for centering absolutely positioned elements
+View: Added `insetInline` and `insetBlock` props, and a `"center"` keyword value for `inset`, `insetInline` and `insetBlock` to center absolutely positioned elements without manual CSS transforms. `inset="center"` centers on both axes, `insetInline`/`insetBlock` center on a single axis.

--- a/packages/reshaped/src/components/View/View.types.ts
+++ b/packages/reshaped/src/components/View/View.types.ts
@@ -101,8 +101,8 @@ export type Props<TagName extends keyof React.JSX.IntrinsicElements | void = voi
 	borderRadius?: G.Responsive<TStyles.Radius>;
 	/** Position style */
 	position?: G.Responsive<TStyles.Position>;
-	/** Inset style, base unit token number multiplier when used as a number */
-	inset?: G.Responsive<TStyles.Inset>;
+	/** Inset style, base unit token number multiplier when used as a number, "center" centers the element on both axes */
+	inset?: G.Responsive<TStyles.InsetAxis>;
 	/** Inset start, base unit token number multiplier when used as a number */
 	insetStart?: G.Responsive<TStyles.Inset>;
 	/** Inset end, base unit token number multiplier when used as a number */

--- a/packages/reshaped/src/components/View/tests/View.stories.tsx
+++ b/packages/reshaped/src/components/View/tests/View.stories.tsx
@@ -1066,6 +1066,18 @@ export const inset = {
 				</View>
 			</Example.Item>
 
+			<Example.Item title="inset: center">
+				<View backgroundColor="neutral-faded" width={25} height={25}>
+					<View
+						backgroundColor="neutral"
+						position="absolute"
+						inset="center"
+						height={10}
+						width={10}
+					/>
+				</View>
+			</Example.Item>
+
 			<Example.Item title="responsive, [s] insetBottom: 4 [m+] insetEnd: 4">
 				<View backgroundColor="neutral-faded" width={25} height={25}>
 					<View

--- a/packages/reshaped/src/styles/resolvers/inset/__snapshots__/index.test.ts.snap
+++ b/packages/reshaped/src/styles/resolvers/inset/__snapshots__/index.test.ts.snap
@@ -2,26 +2,102 @@
 
 exports[`Styles/Inset > handles 0 value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+    ],
+    [
+      "_--block-unit_31d553",
+    ],
+  ],
   "variables": {
-    "--rs-inset-s": 0,
+    "--rs-inset-block-s": 0,
+    "--rs-inset-inline-s": 0,
+  },
+}
+`;
+
+exports[`Styles/Inset > handles center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-center_31d553",
+    ],
+    [
+      "_--block-center_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-block-s": "center",
+    "--rs-inset-inline-s": "center",
   },
 }
 `;
 
 exports[`Styles/Inset > handles positive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+    ],
+    [
+      "_--block-unit_31d553",
+    ],
+  ],
   "variables": {
-    "--rs-inset-s": 4,
+    "--rs-inset-block-s": 4,
+    "--rs-inset-inline-s": 4,
+  },
+}
+`;
+
+exports[`Styles/Inset > handles responsive center value 1`] = `
+{
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-center_31d553",
+      "_--inline-unit--m_31d553",
+    ],
+    [
+      "_--block-center_31d553",
+      "_--block-unit--m_31d553",
+    ],
+  ],
+  "variables": {
+    "--rs-inset-block-m": 4,
+    "--rs-inset-block-s": "center",
+    "--rs-inset-inline-m": 4,
+    "--rs-inset-inline-s": "center",
   },
 }
 `;
 
 exports[`Styles/Inset > handles responsive value 1`] = `
 {
+  "classNames": [
+    "_root_31d553",
+    [
+      "_--inline-unit_31d553",
+      "_--inline-unit--m_31d553",
+      "_--inline-unit--l_31d553",
+    ],
+    [
+      "_--block-unit_31d553",
+      "_--block-unit--m_31d553",
+      "_--block-unit--l_31d553",
+    ],
+  ],
   "variables": {
-    "--rs-inset-l": 2,
-    "--rs-inset-m": 0,
-    "--rs-inset-s": 4,
+    "--rs-inset-block-l": 2,
+    "--rs-inset-block-m": 0,
+    "--rs-inset-block-s": 4,
+    "--rs-inset-inline-l": 2,
+    "--rs-inset-inline-m": 0,
+    "--rs-inset-inline-s": 4,
   },
 }
 `;

--- a/packages/reshaped/src/styles/resolvers/inset/index.test.ts
+++ b/packages/reshaped/src/styles/resolvers/inset/index.test.ts
@@ -25,6 +25,14 @@ describe("Styles/Inset", () => {
 	test("handles responsive value", async () => {
 		expect(inset({ s: 4, m: 0, l: 2 })).toMatchSnapshot();
 	});
+
+	test("handles center value", () => {
+		expect(inset("center")).toMatchSnapshot();
+	});
+
+	test("handles responsive center value", async () => {
+		expect(inset({ s: "center", m: 4 })).toMatchSnapshot();
+	});
 });
 
 describe("Styles/Inset/Top", () => {

--- a/packages/reshaped/src/styles/resolvers/inset/index.ts
+++ b/packages/reshaped/src/styles/resolvers/inset/index.ts
@@ -3,9 +3,30 @@ import * as T from "@/styles/types";
 import s from "./inset.module.css";
 import "./inset.css";
 
-const inset: T.StyleResolver<T.Inset> = (value) => {
+const inset: T.StyleResolver<T.InsetAxis> = (value) => {
 	if (value === undefined) return {};
-	return { variables: responsiveVariables("--rs-inset", value) };
+	// Insetting all sides is sugar for insetting both axes, which also lets
+	// `inset="center"` reuse the per-axis centering classes for both directions
+	const inlineClassNames = responsiveClassNames(
+		s,
+		(value) => (value === "center" ? "--inline-center" : "--inline-unit"),
+		value,
+		{ excludeValueFromClassName: true }
+	);
+	const blockClassNames = responsiveClassNames(
+		s,
+		(value) => (value === "center" ? "--block-center" : "--block-unit"),
+		value,
+		{ excludeValueFromClassName: true }
+	);
+
+	return {
+		classNames: [s.root, inlineClassNames, blockClassNames],
+		variables: {
+			...responsiveVariables("--rs-inset-inline", value),
+			...responsiveVariables("--rs-inset-block", value),
+		},
+	};
 };
 
 export const insetTop: T.StyleResolver<T.Inset> = (value) => {

--- a/packages/reshaped/src/styles/resolvers/inset/inset.css
+++ b/packages/reshaped/src/styles/resolvers/inset/inset.css
@@ -1,9 +1,3 @@
-@responsive [style*="--rs-inset-s:"] {
-	@variable --rs-inset 0;
-
-	inset: calc(var(--rs-inset) * var(--rs-unit-x1));
-}
-
 @responsive [style*="--rs-inset-end-"] {
 	@variable --rs-inset-end 0;
 

--- a/packages/reshaped/src/styles/types.ts
+++ b/packages/reshaped/src/styles/types.ts
@@ -90,7 +90,7 @@ export type Mixin = {
 
 	position?: G.Responsive<Position>;
 	zIndex?: ZIndex;
-	inset?: G.Responsive<Inset>;
+	inset?: G.Responsive<InsetAxis>;
 	insetTop?: G.Responsive<Inset>;
 	insetBottom?: G.Responsive<Inset>;
 	insetStart?: G.Responsive<Inset>;


### PR DESCRIPTION
## Summary

Follow-up to #650, which added the `"center"` keyword to `insetInline` / `insetBlock` for single-axis centering of absolutely positioned elements.

This extends `"center"` to the all-sides **`inset`** prop, so the common case — centering an element on both axes — is a single value:

```tsx
<View position="absolute" inset="center" />           {/* both axes */}
<View position="absolute" insetInline="center" />     {/* horizontal (from #650) */}
<View position="absolute" insetBlock="center" />      {/* vertical (from #650) */}
```

## How it works

The all-sides `inset` resolver is now sugar for insetting **both axes**: it emits the same per-axis inline/block classes and CSS variables that `insetInline`/`insetBlock` use, which lets `inset="center"` reuse the existing centering classes for both directions. The now-dead all-sides rule is removed from `inset.css`.

Centering itself relies on the mechanism introduced in #650 — physical `left`/`top: 50%` plus a `translate` composed from `@property`-typed `--rs-inset-translate-*` variables — so it composes cleanly with responsive values (e.g. `inset={{ s: "center", l: 4 }}` centers on small and switches to a numeric inset from `l` up).

## Testing

- Added resolver snapshots for `inset("center")` and the responsive `{ s: "center", m: 4 }` handoff.
- Added an `inset: center` story to the View `inset` example set (visual coverage via Chromatic).
- `tsc`, `oxlint`, `stylelint`, and the full `test:unit` project (183 tests) pass. Verified the module CSS compiles cleanly through the responsive PostCSS plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)