### PR TITLE
fix(View): pass fallbackKey to renderItem in default children branch

### DIFF
--- a/packages/reshaped/src/components/View/View.tsx
+++ b/packages/reshaped/src/components/View/View.tsx
@@ -278,7 +278,7 @@ const View = <As extends keyof React.JSX.IntrinsicElements = "div">(props: T.Pro
 
 		const usedIndex = renderedItemIndex;
 		renderedItemIndex += 1;
-		return renderItem({ child, index: usedIndex });
+		return renderItem({ child, index: usedIndex, fallbackKey: usedIndex });
 	});
 
 	// Classnames and attributes are written here so we can assign nowrap to the root element based on the children


### PR DESCRIPTION
## Summary

Fix for React key warning. In `View`'s `renderItem`, the default branch (used when a child doesn't match the `Hidden` or multi-child `Fragment` cases) never passes a `fallbackKey`, unlike the other two branches. So when a `View`/`View.Item` child has no explicit `key`, the wrapping `Fragment` ends up keyed with `undefined` — hence the "Each child in a list should have a unique key prop" warning.

Fix: pass `usedIndex` as `fallbackKey`, same as the other branches already do.

## Related Issue

None — found while debugging a React key warning in a consuming app.

## Screenshots / Recordings

<img width="1118" height="237" alt="image" src="https://github.com/user-attachments/assets/ec453204-b8aa-4538-adb5-227f66e4533e" />

No visual change, just a fix for a console warning.

## Notes for Reviewers

Single line change:
```js
return renderItem({ child, index: usedIndex, fallbackKey: usedIndex });
```

Example that triggers the warning before this fix — plain text and a `<br />` as direct children, none with an explicit key:
```jsx
<View as="p" justify="center" textAlign="center">
  {__("Some descriptive text explaining a concept to the user.")}
  <br />
  {__("A second sentence continuing the explanation, on its own line.")}
</View>
```