### PR TITLE
fix: export postcss config subpath with file extension

### DIFF
--- a/.changeset/fix-postcss-config-subpath-extension.md
+++ b/.changeset/fix-postcss-config-subpath-extension.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+PostCSS config: Added `reshaped/config/postcss.js` and `reshaped/config/postcss.cjs` to the package exports, so importing the config with a file extension no longer fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`

--- a/packages/reshaped/package.json
+++ b/packages/reshaped/package.json
@@ -53,6 +53,15 @@
 			"import": "./dist/config/postcss.js",
 			"default": "./dist/config/postcss.cjs"
 		},
+		"./config/postcss.js": {
+			"types": "./dist/config/postcss.d.ts",
+			"import": "./dist/config/postcss.js",
+			"default": "./dist/config/postcss.cjs"
+		},
+		"./config/postcss.cjs": {
+			"types": "./dist/config/postcss.d.cts",
+			"default": "./dist/config/postcss.cjs"
+		},
 		"./bundle": {
 			"types": "./dist/bundle.d.ts",
 			"import": "./dist/bundle.js",


### PR DESCRIPTION
## Summary

A user reported that a Vite project fails to start with `[plugin:vite:css] Failed to load PostCSS config` when their `postcss.config.js` contains:

```js
export { config as default } from 'reshaped/config/postcss.js';
```

The underlying error is `ERR_PACKAGE_PATH_NOT_EXPORTED`: the exports map in `packages/reshaped/package.json` only declared the extensionless `./config/postcss` subpath, so the `.js`-suffixed form — the one that reads naturally in an ESM config file, where relative specifiers do require extensions — was not resolvable. Node's exports resolution is exact string matching, so `./config/postcss` does not cover `./config/postcss.js`.

This adds two aliases alongside the existing subpath:

- `./config/postcss.js` — same targets as the extensionless entry (ESM build for `import`, CJS build for `require`, since requiring the ESM file would throw).
- `./config/postcss.cjs` — points at the CommonJS build and its `dist/config/postcss.d.cts` types. Both files are already published in the tarball, but `.d.cts` was not reachable through any subpath.

Verified all four call styles resolve against the published `reshaped` tarball with the patched exports map:

| specifier | context | result |
| --- | --- | --- |
| `reshaped/config/postcss` | ESM `import` | resolves |
| `reshaped/config/postcss.js` | ESM `import` | resolves (was `ERR_PACKAGE_PATH_NOT_EXPORTED`) |
| `reshaped/config/postcss` | CJS `require` | resolves |
| `reshaped/config/postcss.cjs` | CJS `require` | resolves (was `ERR_PACKAGE_PATH_NOT_EXPORTED`) |

## Related Issue

<!-- Reported via screenshots; no issue number was provided. -->

## Screenshots / Recordings

No UI changes — packaging only.

## Notes for Reviewers

- The existing `./config/postcss` entry is untouched, so this is additive and cannot change resolution for anyone already working today.
- The alternative would have been to keep the exports map as-is and correct the docs to drop the extension. Adding the alias seemed better since both forms are idiomatic depending on the project, and the extension form is what people reach for in an ESM config file.
- Worth a sanity check on whether the docs site examples show the `.js` form — if so, they now match reality either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgWbR7T7YW1ni45Qy4Um8A)_