### PR TITLE
feat: use caption-1 text for the small size of Button, MenuItem, Tabs and form fields

### DIFF
--- a/.changeset/small-size-caption-text.md
+++ b/.changeset/small-size-caption-text.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Button, MenuItem, Tabs, TextField, Select and PinField: Small size now renders caption-1 text, their vertical padding grows by the line height difference so the component size stays the same

--- a/packages/reshaped/src/components/Button/Button.module.css
+++ b/packages/reshaped/src/components/Button/Button.module.css
@@ -143,8 +143,10 @@
 
 @responsive .--size {
 	@value small {
-		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
-		--rs-button-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
+		/* Padding absorbs the caption-1 line height difference to keep the size it had with body-2 text */
+		--rs-button-p-v: calc(
+			var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+		);
 		--rs-button-p-h: var(--rs-unit-x2);
 		--rs-button-gap: var(--rs-unit-x1-5);
 		--rs-button-icon-align: var(--rs-unit-x0-5);

--- a/packages/reshaped/src/components/Button/Button.module.css
+++ b/packages/reshaped/src/components/Button/Button.module.css
@@ -6,6 +6,7 @@
 	/* Using --rs-button-p and --rs-p to dynamically reassign --rs-p for all sizes of ghost buttons, used by Aligner */
 	--rs-p-v: var(--rs-button-p-v);
 	--rs-p-h: var(--rs-button-p-h);
+	--rs-button-min-size: calc(var(--rs-button-line-height) + var(--rs-button-p-v) * 2);
 
 	transition: var(--rs-duration-fast) var(--rs-easing-standard);
 	transition-property: background-color, box-shadow, border-color, color, transform, opacity;
@@ -29,10 +30,10 @@
 	line-height: var(--rs-button-line-height);
 	letter-spacing: var(--rs-button-letter-spacing);
 	box-sizing: border-box;
-	min-height: calc(var(--rs-button-line-height) + var(--rs-p-v) * 2);
-	min-width: calc(
-		var(--rs-button-line-height) - (var(--rs-unit-x1) * 2) + (var(--rs-button-p-h) * 2)
-	);
+
+	/* Keeps icon-only buttons square by using the same value for both dimensions */
+	min-height: var(--rs-button-min-size);
+	min-width: var(--rs-button-min-size);
 	background-color: var(--rs-button-background-color);
 	color: var(--rs-button-color);
 	isolation: isolate;
@@ -142,13 +143,14 @@
 
 @responsive .--size {
 	@value small {
-		--rs-button-p-v: var(--rs-unit-x1);
+		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
+		--rs-button-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
 		--rs-button-p-h: var(--rs-unit-x2);
 		--rs-button-gap: var(--rs-unit-x1-5);
 		--rs-button-icon-align: var(--rs-unit-x0-5);
-		--rs-button-line-height: var(--rs-line-height-body-2);
-		--rs-button-font-size: var(--rs-font-size-body-2);
-		--rs-button-letter-spacing: var(--rs-letter-spacing-body-2);
+		--rs-button-line-height: var(--rs-line-height-caption-1);
+		--rs-button-font-size: var(--rs-font-size-caption-1);
+		--rs-button-letter-spacing: var(--rs-letter-spacing-caption-1);
 		--rs-button-radius: var(--rs-radius-small);
 	}
 

--- a/packages/reshaped/src/components/MenuItem/MenuItem.module.css
+++ b/packages/reshaped/src/components/MenuItem/MenuItem.module.css
@@ -32,8 +32,10 @@ button.root {
 
 @responsive .--size {
 	@value small {
-		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
-		--rs-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
+		/* Padding absorbs the caption-1 line height difference to keep the size it had with body-2 text */
+		--rs-p-v: calc(
+			var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+		);
 		--rs-p-h: var(--rs-unit-x1-5);
 		--rs-menu-item-radius: var(--rs-radius-small);
 

--- a/packages/reshaped/src/components/MenuItem/MenuItem.module.css
+++ b/packages/reshaped/src/components/MenuItem/MenuItem.module.css
@@ -32,13 +32,14 @@ button.root {
 
 @responsive .--size {
 	@value small {
-		--rs-p-v: var(--rs-unit-x1);
+		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
+		--rs-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
 		--rs-p-h: var(--rs-unit-x1-5);
 		--rs-menu-item-radius: var(--rs-radius-small);
 
-		font-size: var(--rs-font-size-body-2);
-		line-height: var(--rs-line-height-body-2);
-		letter-spacing: var(--rs-letter-spacing-body-2);
+		font-size: var(--rs-font-size-caption-1);
+		line-height: var(--rs-line-height-caption-1);
+		letter-spacing: var(--rs-letter-spacing-caption-1);
 	}
 
 	@value medium {

--- a/packages/reshaped/src/components/PinField/PinFieldControlled.tsx
+++ b/packages/reshaped/src/components/PinField/PinFieldControlled.tsx
@@ -45,9 +45,11 @@ const PinFieldControlled: React.FC<T.ControlledProps> = (props) => {
 	} = props;
 	const patternRegexp = patternMap[pattern];
 	const responsiveInputSize = responsivePropDependency(size, (value) => sizeMap[value]);
-	const responsiveTextVariant = responsivePropDependency(size, (value) =>
-		value === "medium" ? "body-2" : "body-1"
-	);
+	const responsiveTextVariant = responsivePropDependency(size, (value) => {
+		if (value === "small") return "caption-1";
+		if (value === "medium") return "body-2";
+		return "body-1";
+	});
 	const responsiveRadius = responsivePropDependency(size, (value) =>
 		value === "small" ? "small" : "medium"
 	);

--- a/packages/reshaped/src/components/Reshaped/Reshaped.css
+++ b/packages/reshaped/src/components/Reshaped/Reshaped.css
@@ -4,6 +4,15 @@
 		--rs-outline: var(--rs-outline-width) solid var(--rs-color-border-primary);
 		--rs-outline-shadow: 0 0 0 var(--rs-outline-width) var(--rs-color-border-primary) inset;
 		--rs-radius-circular: 9999px;
+
+		/*
+		Small components render caption-1 text while keeping the height they had with body-2 text.
+		Their vertical padding grows by this value on each side to compensate for the line height difference.
+		Themes where both line heights match resolve it to 0 and stay unaffected.
+		*/
+		--rs-caption-1-line-height-offset: calc(
+			(var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+		);
 	}
 
 	[data-rs-theme] body,

--- a/packages/reshaped/src/components/Reshaped/Reshaped.css
+++ b/packages/reshaped/src/components/Reshaped/Reshaped.css
@@ -4,15 +4,6 @@
 		--rs-outline: var(--rs-outline-width) solid var(--rs-color-border-primary);
 		--rs-outline-shadow: 0 0 0 var(--rs-outline-width) var(--rs-color-border-primary) inset;
 		--rs-radius-circular: 9999px;
-
-		/*
-		Small components render caption-1 text while keeping the height they had with body-2 text.
-		Their vertical padding grows by this value on each side to compensate for the line height difference.
-		Themes where both line heights match resolve it to 0 and stay unaffected.
-		*/
-		--rs-caption-1-line-height-offset: calc(
-			(var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
-		);
 	}
 
 	[data-rs-theme] body,

--- a/packages/reshaped/src/components/Select/Select.module.css
+++ b/packages/reshaped/src/components/Select/Select.module.css
@@ -108,8 +108,10 @@
 		--rs-select-chevron-size: var(--rs-unit-x4);
 		--rs-select-radius: var(--rs-radius-small);
 
-		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
-		--rs-select-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
+		/* Padding absorbs the caption-1 line height difference to keep the size it had with body-2 text */
+		--rs-select-p-v: calc(
+			var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+		);
 		--rs-select-p-h: var(--rs-unit-x2);
 		--rs-select-font-size: var(--rs-font-size-caption-1);
 		--rs-select-line-height: var(--rs-line-height-caption-1);

--- a/packages/reshaped/src/components/Select/Select.module.css
+++ b/packages/reshaped/src/components/Select/Select.module.css
@@ -107,13 +107,15 @@
 		--rs-select-gap: var(--rs-unit-x1-5);
 		--rs-select-chevron-size: var(--rs-unit-x4);
 		--rs-select-radius: var(--rs-radius-small);
-		--rs-select-p-v: var(--rs-unit-x1);
+
+		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
+		--rs-select-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
 		--rs-select-p-h: var(--rs-unit-x2);
-		--rs-select-font-size: var(--rs-font-size-body-2);
-		--rs-select-line-height: var(--rs-line-height-body-2);
-		--rs-select-letter-spacing: var(--rs-letter-spacing-body-2);
+		--rs-select-font-size: var(--rs-font-size-caption-1);
+		--rs-select-line-height: var(--rs-line-height-caption-1);
+		--rs-select-letter-spacing: var(--rs-letter-spacing-caption-1);
 		--rs-select-icon-align: var(--rs-unit-x0-5);
-		--rs-select-min-height: calc(var(--rs-select-line-height) + var(--rs-unit-x1) * 2);
+		--rs-select-min-height: calc(var(--rs-select-line-height) + var(--rs-select-p-v) * 2);
 	}
 
 	@value medium {

--- a/packages/reshaped/src/components/Tabs/Tabs.module.css
+++ b/packages/reshaped/src/components/Tabs/Tabs.module.css
@@ -355,7 +355,8 @@
 }
 
 .--size-small {
-	--rs-tabs-item-p-v: var(--rs-unit-x1);
+	/* Padding grows by the line height difference to keep the size the same as with body-2 text */
+	--rs-tabs-item-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
 	--rs-tabs-item-p-h: var(--rs-unit-x2);
 	--rs-tabs-icon-gap: var(--rs-unit-x1-5);
 	--rs-tabs-radius: var(--rs-radius-small);

--- a/packages/reshaped/src/components/Tabs/Tabs.module.css
+++ b/packages/reshaped/src/components/Tabs/Tabs.module.css
@@ -355,8 +355,10 @@
 }
 
 .--size-small {
-	/* Padding grows by the line height difference to keep the size the same as with body-2 text */
-	--rs-tabs-item-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
+	/* Padding absorbs the caption-1 line height difference to keep the size it had with body-2 text */
+	--rs-tabs-item-p-v: calc(
+		var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+	);
 	--rs-tabs-item-p-h: var(--rs-unit-x2);
 	--rs-tabs-icon-gap: var(--rs-unit-x1-5);
 	--rs-tabs-radius: var(--rs-radius-small);

--- a/packages/reshaped/src/components/Tabs/TabsItem.tsx
+++ b/packages/reshaped/src/components/Tabs/TabsItem.tsx
@@ -87,7 +87,7 @@ const TabsItem = React.forwardRef<ActionableRef, T.ItemProps>((props, ref) => {
 				{icon && <Icon svg={icon} className={s.icon} size={4} />}
 				{children && (
 					<Text
-						variant={size === "large" ? "body-1" : "body-2"}
+						variant={size === "large" ? "body-1" : size === "small" ? "caption-1" : "body-2"}
 						weight="medium"
 						className={s.buttonText}
 					>

--- a/packages/reshaped/src/components/TextField/TextField.module.css
+++ b/packages/reshaped/src/components/TextField/TextField.module.css
@@ -195,8 +195,10 @@
 		--rs-text-field-gap: var(--rs-unit-x1-5);
 		--rs-text-field-radius: var(--rs-radius-small);
 
-		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
-		--rs-text-field-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
+		/* Padding absorbs the caption-1 line height difference to keep the size it had with body-2 text */
+		--rs-text-field-p-v: calc(
+			var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2
+		);
 		--rs-text-field-p-h: var(--rs-unit-x2);
 		--rs-text-field-icon-align: var(--rs-unit-x0-5);
 		--rs-text-field-font-size: var(--rs-font-size-caption-1);

--- a/packages/reshaped/src/components/TextField/TextField.module.css
+++ b/packages/reshaped/src/components/TextField/TextField.module.css
@@ -194,14 +194,18 @@
 	@value small {
 		--rs-text-field-gap: var(--rs-unit-x1-5);
 		--rs-text-field-radius: var(--rs-radius-small);
-		--rs-text-field-p-v: var(--rs-unit-x1);
+
+		/* Padding grows by the line height difference to keep the size the same as with body-2 text */
+		--rs-text-field-p-v: calc(var(--rs-unit-x1) + var(--rs-caption-1-line-height-offset));
 		--rs-text-field-p-h: var(--rs-unit-x2);
 		--rs-text-field-icon-align: var(--rs-unit-x0-5);
-		--rs-text-field-font-size: var(--rs-font-size-body-2);
-		--rs-text-field-line-height: var(--rs-line-height-body-2);
-		--rs-text-field-letter-spacing: var(--rs-letter-spacing-body-2);
+		--rs-text-field-font-size: var(--rs-font-size-caption-1);
+		--rs-text-field-line-height: var(--rs-line-height-caption-1);
+		--rs-text-field-letter-spacing: var(--rs-letter-spacing-caption-1);
 		--rs-text-field-action-inset: var(--rs-unit-x1);
-		--rs-text-field-min-height: calc(var(--rs-text-field-line-height) + var(--rs-unit-x1) * 2);
+		--rs-text-field-min-height: calc(
+			var(--rs-text-field-line-height) + var(--rs-text-field-p-v) * 2
+		);
 	}
 
 	@value medium {


### PR DESCRIPTION
## Summary

`Button`, `MenuItem`, `Tabs`, `TextField`, `Select` and `PinField` rendered `body-2` text in their `small` size — the same variant as `medium`. They now render `caption-1`, matching `Checkbox` and `Radio`, which already do.

`caption-1` has a smaller line height, so the components would have shrunk. Their vertical padding grows by half of the line height difference on each side, keeping the rendered size identical:

- Each small size writes its vertical padding as `calc(var(--rs-unit-x1) + (var(--rs-line-height-body-2) - var(--rs-line-height-caption-1)) / 2)`, deriving the compensation from the theme rather than hardcoding it. In the `figma` theme, where both line heights are already `1rem`, it resolves to `0` and nothing changes.
- `Button` `min-width` was written as `line-height − x1 * 2 + p-h * 2`, which only equalled `min-height` because horizontal padding happened to be exactly one unit larger than vertical padding at every size. That no longer holds for `small`, so both dimensions now read the same `--rs-button-min-size` value and icon-only buttons stay square.
- `Tabs` and `PinField` size their items independently of the text, so they only switch the `Text` variant.

Also bumped `PinField`'s `small` size off `body-1`, which was larger than the `body-2` used by `medium`.

`TextArea` is not included — its `size` prop is `medium | large | xlarge`, so it has no small size to change.

## Related Issue

N/A

## Screenshots / Recordings

Measured in Chromium against the built CSS, comparing the branch to `canary` (slate theme, `small` rows are the ones that changed):

| case | before | after |
| --- | --- | --- |
| Button / small / text | 28×50.27 (14px) | 28×45.38 (12px) |
| Button / small / icon-only | 28×28 (14px) | 28×28 (12px) |
| Button / medium / text | 36×58.27 (14px) | 36×58.27 (14px) |
| Button / large / icon-only | 48×48 (16px) | 48×48 (16px) |
| Button / xlarge / text | 56×84.05 (18px) | 56×84.05 (18px) |
| MenuItem / small / text | 28×46.27 (14px) | 28×41.38 (12px) |
| MenuItem / small / icon | 28×70.27 (14px) | 28×65.38 (12px) |
| MenuItem / medium / text | 36×58.27 (14px) | 36×58.27 (14px) |
| Tabs / small / item | 28×50.27 | 28×45.38 |
| Tabs / small / item with icon | 28×72.27 | 28×67.38 |
| Tabs / medium / item | 36×58.27 | 36×58.27 |
| TextField / small | 28×197 | 28×171 |
| TextField / small / icon + affix | 28×238.8 | 28×210.69 |
| TextField / medium | 36×205 | 36×205 |
| TextField / xlarge | 56×247 | 56×247 |
| Select / small | 28×73 | 28×68 |
| Select / medium | 36×83 | 36×83 |
| Select / large | 48×100 | 48×100 |

Heights are unchanged everywhere; only font size and intrinsic width shrink. The same comparison against the `figma` theme is byte-identical before and after, since its `body-2` and `caption-1` line heights match.

## Notes for Reviewers

- The compensation is derived from the line height tokens rather than written as a fixed `x1-5` on purpose — hardcoding it would grow small components by 4px in any theme where the two line heights are already equal.
- Worth a Chromatic run given this touches every small-size component.