### PR TITLE
fix(Accordion): don't replay the expand animation when effects are re-attached

### DIFF
--- a/.changeset/fix-accordion-animation-replay.md
+++ b/.changeset/fix-accordion-animation-replay.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Accordion: Fixed the expand animation replaying when React re-attaches the effects of a mounted accordion without changing its state, for example when it's moved between its siblings or hidden and shown by a Suspense boundary. Toggling the accordion while it's still animating now continues from the current height instead of jumping, and transitions bubbling up from the content no longer end the animation early.

--- a/packages/reshaped/src/components/_private/Expandable/Expandable.tsx
+++ b/packages/reshaped/src/components/_private/Expandable/Expandable.tsx
@@ -12,6 +12,8 @@ const Expandable: React.FC<T.ContentProps> = (props) => {
 	const { children, active, attributes } = props;
 	const rootRef = React.useRef<HTMLDivElement>(null);
 	const mountedRef = React.useRef(false);
+	const animatedActiveRef = React.useRef(active);
+	const frameRef = React.useRef<number | null>(null);
 	const [animatedHeight, setAnimatedHeight] = React.useState<React.CSSProperties["height"] | null>(
 		active ? "auto" : null
 	);
@@ -22,7 +24,7 @@ const Expandable: React.FC<T.ContentProps> = (props) => {
 	);
 
 	const handleTransitionEnd = (e: React.TransitionEvent) => {
-		if (e.propertyName !== "height") return;
+		if (e.propertyName !== "height" || e.target !== rootRef.current) return;
 
 		setAnimatedHeight(active ? "auto" : null);
 	};
@@ -35,33 +37,45 @@ const Expandable: React.FC<T.ContentProps> = (props) => {
 		});
 	}, []);
 
+	// Animating only on the active prop change keeps React from replaying the animation
+	// when it tears down and sets up the effects of the mounted component again
 	useIsomorphicLayoutEffect(() => {
 		const rootEl = rootRef.current;
-		if (!rootEl || !mountedRef.current) return;
+		const activeChanged = animatedActiveRef.current !== active;
 
-		if (!checkTransitions()) {
+		animatedActiveRef.current = active;
+
+		if (!rootEl || !activeChanged) return;
+
+		if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+		frameRef.current = null;
+
+		const settle = () => {
+			rootEl.style.height = "";
 			setAnimatedHeight(active ? "auto" : null);
+		};
+
+		if (!mountedRef.current || !checkTransitions()) {
+			settle();
 			return;
 		}
 
-		if (active) {
-			rootEl.style.height = "auto";
+		const currentHeight = rootEl.clientHeight;
 
-			requestAnimationFrame(() => {
-				const targetHeight = rootEl.clientHeight;
-				rootEl.style.height = "0";
+		if (active) rootEl.style.height = "auto";
+		const targetHeight = active ? rootEl.clientHeight : 0;
 
-				requestAnimationFrame(() => {
-					setAnimatedHeight(targetHeight);
-				});
-			});
-		} else {
-			rootEl.style.height = `${rootEl.clientHeight}px`;
-
-			requestAnimationFrame(() => {
-				setAnimatedHeight(0);
-			});
+		if (targetHeight === currentHeight) {
+			settle();
+			return;
 		}
+
+		rootEl.style.height = `${currentHeight}px`;
+
+		frameRef.current = requestAnimationFrame(() => {
+			frameRef.current = null;
+			setAnimatedHeight(targetHeight);
+		});
 	}, [active]);
 
 	return (


### PR DESCRIPTION
## Summary

`Expandable` drove its height animation from a layout effect that measured and animated on **every** run. The effect's only dependency is `active`, but React tears down and sets up effects without any prop change — when a subtree is moved between its siblings, or when a Suspense boundary hides and shows already-mounted content. Every one of those replayed the open animation from `0`, which reads as a flicker on an accordion that was already expanded.

The fix tracks the state we've already animated to in a ref, so the animation is driven by an actual `active` change rather than by the effect running:

```ts
const activeChanged = animatedActiveRef.current !== active;

animatedActiveRef.current = active;
if (!rootEl || !activeChanged) return;
```

A few related edge cases fixed while in there:

- **Interrupted animations.** The frames scheduled by the previous animation are cancelled, so toggling mid-animation isn't reverted by a stale `requestAnimationFrame` from the previous direction (opening → closing quickly could end up re-opening).
- **No snap to `0`.** The target height is now measured synchronously in the layout effect instead of a frame later, and the animation starts from the current height. Reopening mid-close continues from where it is rather than jumping.
- **Nothing to animate.** When the measured target equals the current height — empty content, or an accordion toggled inside a `display: none` container — the height settles immediately instead of waiting for a `transitionend` that never fires and getting stuck at `0`.
- **Bubbled transitions.** `transitionend` is now ignored unless it comes from the expandable itself, so a `height` transition on the content no longer ends the animation early.

No API, DOM or CSS changes — `Accordion.Content` still renders a single element and still switches to `height: auto; overflow: visible` once it's fully open.

## Related Issue

N/A

## Screenshots / Recordings

Frame-by-frame samples taken in the browser test runner confirm the animation itself is unchanged, and that it now settles correctly:

```
open   0 → 6 → 24 → 35 → 42 → 47 → 51 → 53 → 55 → 57 → 58 → inline=auto, overflow=visible
close  58 → 52 → 34 → 23 → 16 → … → 0, inline height cleared, hidden=true
```

## Notes for Reviewers

The bug was verified with a throwaway story that suspends and un-suspends a boundary around a mounted, expanded accordion — it fails on `canary` with `expected '58px' to be 'auto'` (the animation replaying) and passes with this change. It isn't part of the diff.

The existing `Accordion` stories all pass, and `pnpm test:browser` is green apart from `Image > onLoad`, which fails on `canary` too in this sandbox because the remote image can't be fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQQbNjDfHyvtxshEp5HSB6