### PR TITLE
feat(Link): add fullWidth support

### DIFF
--- a/.changeset/link-full-width.md
+++ b/.changeset/link-full-width.md
@@ -1,0 +1,5 @@
+---
+"reshaped": minor
+---
+
+Link: Added a fullWidth prop for making the link take the full width of its parent element, it supports responsive values

--- a/packages/reshaped/src/components/Link/Link.module.css
+++ b/packages/reshaped/src/components/Link/Link.module.css
@@ -59,3 +59,23 @@
 	align-items: center;
 	gap: round(down, calc(1em / 2.5), var(--rs-unit-x1));
 }
+
+@responsive .root.--full-width {
+	@value true {
+		display: block;
+		width: 100%;
+
+		&.--with-icon {
+			display: flex;
+		}
+	}
+
+	@value false {
+		display: inline;
+		width: auto;
+
+		&.--with-icon {
+			display: inline-flex;
+		}
+	}
+}

--- a/packages/reshaped/src/components/Link/Link.tsx
+++ b/packages/reshaped/src/components/Link/Link.tsx
@@ -3,6 +3,7 @@ import { classNames } from "@reshaped/utilities";
 
 import Actionable, { type ActionableRef } from "@/components/Actionable";
 import Icon from "@/components/Icon";
+import { responsiveClassNames } from "@/utilities/props";
 import type * as T from "./Link.types";
 import s from "./Link.module.css";
 
@@ -13,6 +14,7 @@ const Link = forwardRef<ActionableRef, T.Props>((props, ref) => {
 		href,
 		color = "primary",
 		variant = "underline",
+		fullWidth,
 		className,
 		children,
 		attributes,
@@ -27,7 +29,8 @@ const Link = forwardRef<ActionableRef, T.Props>((props, ref) => {
 		disabled && s["--disabled"],
 		variant && s[`--variant-${variant}`],
 		color && s[`--color-${color}`],
-		icon && s["--with-icon"]
+		icon && s["--with-icon"],
+		responsiveClassNames(s, "--full-width", fullWidth)
 	);
 
 	return (

--- a/packages/reshaped/src/components/Link/Link.types.ts
+++ b/packages/reshaped/src/components/Link/Link.types.ts
@@ -1,5 +1,6 @@
 import type { ActionableProps } from "@/components/Actionable";
 import type { IconProps } from "@/components/Icon";
+import type * as G from "@/types/global";
 
 export type Props = Pick<
 	ActionableProps,
@@ -23,4 +24,6 @@ export type Props = Pick<
 	 * @default "underline"
 	 */
 	variant?: "plain" | "underline";
+	/** Make the component take the full width of the parent element */
+	fullWidth?: G.Responsive<boolean>;
 };

--- a/packages/reshaped/src/components/Link/tests/Link.stories.tsx
+++ b/packages/reshaped/src/components/Link/tests/Link.stories.tsx
@@ -94,6 +94,34 @@ export const icon = {
 	),
 };
 
+export const fullWidth: StoryObj = {
+	name: "fullWidth",
+	render: () => (
+		<Example>
+			<Example.Item title="fullWidth">
+				<Link fullWidth href="https://reshaped.so">
+					Link
+				</Link>
+			</Example.Item>
+			<Example.Item title="fullWidth, with icon">
+				<Link fullWidth icon={IconZap} href="https://reshaped.so">
+					Link
+				</Link>
+			</Example.Item>
+			<Example.Item title={["responsive fullWidth", "[s] true", "[m+] false"]}>
+				<Link fullWidth={{ s: true, m: false }} href="https://reshaped.so">
+					Link
+				</Link>
+			</Example.Item>
+		</Example>
+	),
+	play: async ({ canvas }) => {
+		const el = canvas.getAllByRole("link")[0];
+
+		expect(el).toHaveStyle({ display: "block" });
+	},
+};
+
 export const href: StoryObj = {
 	name: "href",
 	render: () => <Link href="https://reshaped.so">Trigger</Link>,


### PR DESCRIPTION
## Summary

Adds a responsive `fullWidth` prop to `Link`, matching the API already used by `Button` (`G.Responsive<boolean>`).

`Link` renders as `display: inline` by default, so `width: 100%` alone has no effect. The prop therefore switches the display mode as well:

| state | `display` | `width` |
| --- | --- | --- |
| `fullWidth` | `block` | `100%` |
| `fullWidth` + `icon` | `flex` | `100%` |
| not full width | `inline` | `auto` |
| not full width + `icon` | `inline-flex` | `auto` |

The `--with-icon` case is handled inside both the `true` and `false` `@value` blocks so that responsive values reset correctly at every breakpoint — the nested selectors carry higher specificity than the base `.root.--with-icon` rule, and the generated media-query rules keep matching specificity so a later breakpoint can override an earlier one.

Unlike `Button`, this does not force `text-align: center` — that reads as button-specific and would be surprising for a text link.

Changes:
- `Link.types.ts` — new `fullWidth?: G.Responsive<boolean>` prop
- `Link.tsx` — wires it through `responsiveClassNames`, same as `Button`
- `Link.module.css` — new `@responsive .root.--full-width` block
- `Link.stories.tsx` — `fullWidth` story (plain, with icon, and responsive `{ s: true, m: false }`) with a `display: block` assertion
- changeset (`minor`)

## Related Issue

<!-- Link to the issue number if applicable -->

## Screenshots / Recordings

No screenshots attached — the new `fullWidth` story covers the plain, with-icon, and responsive cases and will be picked up by the Chromatic VRT run.

## Notes for Reviewers

- The display-mode switching is the part worth a close look. Verified the compiled output through the repo's actual postcss pipeline (`build:css`) to confirm selector ordering and specificity resolve as intended across breakpoints.
- `fullWidth` is handled entirely in `Link`'s own CSS rather than being forwarded to `Actionable`'s non-responsive `fullWidth` prop — this mirrors how `Button` does it.

Verification run locally: `lint:format`, `lint:js`, `lint:css` clean; `tsc -p tsconfig.stories.json --noEmit` clean; all 11 Link storybook browser tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjFCq7E3Z9XeVi5yAd1g8A

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjFCq7E3Z9XeVi5yAd1g8A)_