### PR TITLE
fix(Flyout): close content on right click outside

### DIFF
--- a/.changeset/fix-flyout-right-click-outside.md
+++ b/.changeset/fix-flyout-right-click-outside.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Flyout: Fixed content staying open when right clicking outside of it, for example when opening multiple ContextMenu components one after another

--- a/packages/reshaped/src/components/ContextMenu/tests/ContextMenu.stories.tsx
+++ b/packages/reshaped/src/components/ContextMenu/tests/ContextMenu.stories.tsx
@@ -97,6 +97,82 @@ export const handlers: StoryObj<{
 	},
 };
 
+export const outsideRightClick: StoryObj<{
+	handleClose: ReturnType<typeof fn>;
+}> = {
+	name: "test: closing on right click outside",
+	args: {
+		handleClose: fn(),
+	},
+	render: (args) => (
+		<View gap={4}>
+			<ContextMenu onClose={args.handleClose}>
+				<View
+					height="60px"
+					backgroundColor="neutral-faded"
+					borderRadius="medium"
+					attributes={{ "data-testid": "first" }}
+				/>
+
+				<ContextMenu.Content>
+					<ContextMenu.Item>First item</ContextMenu.Item>
+				</ContextMenu.Content>
+			</ContextMenu>
+
+			<ContextMenu>
+				<View
+					height="60px"
+					backgroundColor="neutral-faded"
+					borderRadius="medium"
+					attributes={{ "data-testid": "second" }}
+				/>
+
+				<ContextMenu.Content>
+					<ContextMenu.Item>Second item</ContextMenu.Item>
+				</ContextMenu.Content>
+			</ContextMenu>
+		</View>
+	),
+	play: async ({ canvasElement, args }) => {
+		const canvas = within(canvasElement.ownerDocument.body);
+
+		await userEvent.pointer({ keys: "[MouseRight]", target: canvas.getByTestId("first") });
+
+		expect(canvas.getByText("First item")).toBeInTheDocument();
+
+		// Wait for the open animation to finish
+		await sleep(500);
+
+		// Opening another context menu should close the previous one
+		await userEvent.pointer({ keys: "[MouseRight]", target: canvas.getByTestId("second") });
+
+		expect(args.handleClose).toHaveBeenCalledTimes(1);
+		expect(args.handleClose).toHaveBeenCalledWith({ reason: "outside-click" });
+		expect(canvas.getByText("Second item")).toBeInTheDocument();
+
+		await waitFor(
+			() => {
+				expect(canvas.queryByText("First item")).not.toBeInTheDocument();
+			},
+			{
+				timeout: 1000,
+			}
+		);
+
+		// Wait for the open animation to finish
+		await sleep(500);
+
+		// Right clicking the same area again keeps the menu rendered and moves it to the new position
+		await userEvent.pointer({ keys: "[MouseRight]", target: canvas.getByTestId("second") });
+
+		expect(canvas.getByText("Second item")).toBeInTheDocument();
+
+		await sleep(500);
+
+		expect(canvas.getByText("Second item")).toBeInTheDocument();
+	},
+};
+
 const menuData = [
 	{ label: "Action 1" },
 	{ label: "Action 2" },

--- a/packages/reshaped/src/hooks/tests/useOnClickOutside.stories.tsx
+++ b/packages/reshaped/src/hooks/tests/useOnClickOutside.stories.tsx
@@ -57,6 +57,26 @@ export const base: StoryObj<{ handleOutsideClick: Mock }> = {
 	},
 };
 
+export const rightClick: StoryObj<{ handleOutsideClick: Mock }> = {
+	name: "test: right click",
+	args: {
+		handleOutsideClick: fn(),
+	},
+	render: (args) => <DemoBase onOutsideClick={args.handleOutsideClick} />,
+	play: async ({ canvas, args }) => {
+		const button = canvas.getAllByRole("button")[0];
+
+		await userEvent.pointer({ keys: "[MouseRight]", target: button });
+
+		expect(args.handleOutsideClick).not.toHaveBeenCalled();
+
+		await userEvent.pointer({ keys: "[MouseRight]", target: document.body });
+
+		expect(args.handleOutsideClick).toHaveBeenCalledTimes(1);
+		expect(args.handleOutsideClick).toHaveBeenCalledWith();
+	},
+};
+
 const DemoRefs = (props: { onOutsideClick: () => void }) => {
 	const ref = React.useRef(null);
 	const ref2 = React.useRef(null);

--- a/packages/reshaped/src/hooks/useOnClickOutside.ts
+++ b/packages/reshaped/src/hooks/useOnClickOutside.ts
@@ -3,8 +3,20 @@ import { keys } from "@reshaped/utilities";
 
 import useHandlerRef from "./useHandlerRef";
 
+type Refs = React.RefObject<HTMLElement | null>[];
+
+const checkEventInsideRefs = (refs: Refs, event: Event) => {
+	const targetEl = event.composedPath()[0] as HTMLElement | undefined;
+	if (!targetEl) return false;
+
+	return refs.some((elRef) => {
+		const el = elRef.current;
+		return !!el && (el === targetEl || el.contains(targetEl));
+	});
+};
+
 const useOnClickOutside = (
-	refs: React.RefObject<HTMLElement | null>[],
+	refs: Refs,
 	handler: (event: Event) => void,
 	options?: { disabled?: boolean }
 ) => {
@@ -24,16 +36,7 @@ const useOnClickOutside = (
 		 */
 
 		const handleMouseDown = (event: MouseEvent | TouchEvent | KeyboardEvent) => {
-			isMouseDownInsideRef.current = false;
-
-			const clickedEl = event.composedPath()[0] as HTMLElement;
-
-			refs.forEach((elRef) => {
-				if (!elRef.current) return;
-				if (elRef.current === clickedEl || elRef.current.contains(clickedEl as HTMLElement)) {
-					isMouseDownInsideRef.current = true;
-				}
-			});
+			isMouseDownInsideRef.current = checkEventInsideRefs(refs, event);
 		};
 
 		const handleKeyDown = (event: KeyboardEvent) => {
@@ -58,14 +61,33 @@ const useOnClickOutside = (
 		if (disabled) return;
 
 		const handleClick = (event: MouseEvent | TouchEvent) => {
+			// Right click doesn't trigger the click event in most browsers, it's handled with the contextmenu event
 			if ("button" in event && event.button === 2) return;
 			if (isMouseDownInsideRef.current) return;
 			handlerRef.current?.(event);
 		};
 
+		/**
+		 * Right click doesn't produce a click event, so we handle it separately.
+		 * Checking the target synchronously since the contextmenu event can also be triggered
+		 * with a keyboard, without a preceding mousedown event.
+		 */
+		const handleContextMenu = (event: MouseEvent) => {
+			if (checkEventInsideRefs(refs, event)) return;
+			handlerRef.current?.(event);
+		};
+
 		document.addEventListener("click", handleClick);
+		/**
+		 * Using the capture phase to close the currently rendered content
+		 * before another component opens its own content on the same event,
+		 * e.g. when right clicking between multiple context menus
+		 */
+		document.addEventListener("contextmenu", handleContextMenu, { capture: true });
+
 		return () => {
 			document.removeEventListener("click", handleClick);
+			document.removeEventListener("contextmenu", handleContextMenu, { capture: true });
 		};
 		// oxlint-disable-next-line react-hooks/exhaustive-deps
 	}, [handlerRef, disabled, ...refs]);


### PR DESCRIPTION
## Summary

Flyout only reacted to the `click` event when detecting outside clicks, and browsers don't emit `click` for the secondary mouse button — `useOnClickOutside` even had an explicit `event.button === 2` guard. So right clicking outside of the rendered content never closed it. It's most noticeable with `ContextMenu`: every right click opened a new menu while all the previous ones stayed on the screen.

`useOnClickOutside` now also listens for the `contextmenu` event:

- The listener is registered in the **capture** phase, so the currently rendered content closes *before* another component opens its own content on the same event. That lets `ContextMenu` components replace each other instead of stacking up. Right clicking the same area again still just moves the menu to the new position, because both state updates are batched into a single render.
- The target check runs synchronously off the event instead of reusing the `mousedown` result, since `contextmenu` can also be triggered from the keyboard (`Shift+F10` / the context menu key) with no preceding `mousedown`.
- Everything still goes through the existing `disabled` option, so `disableCloseOnOutsideClick` keeps working and the close reason stays `outside-click`.

The inside-the-refs check used by `mousedown`/`touchstart` was extracted into a shared `checkEventInsideRefs` helper so both paths stay in sync.

## Related Issue

N/A

## Screenshots / Recordings

N/A — covered by the interaction tests below.

## Notes for Reviewers

Tests added:

- `Hooks/useOnClickOutside` → `test: right click` — right clicking the trigger doesn't fire the handler, right clicking the body does.
- `Components/ContextMenu` → `test: closing on right click outside` — right clicking a second context menu closes the first one with `reason: "outside-click"` and opens the second, and right clicking the same area again keeps the menu rendered.

Both fail on `main` and pass with this change. Full `test:browser` run for the package: 588 passed, with one pre-existing unrelated failure (`Image > onLoad`, image loading in the sandbox) that also fails on a clean checkout.

The capture phase is the part worth a second look: it's what makes the close-then-open ordering work for `ContextMenu`, since `ContextMenu` registers its own `contextmenu` listener on the origin element in the bubble phase. Consumers now see `onClose` followed by `onOpen` when moving between context menus, where previously they only saw a second `onOpen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199DZfVd4fASrAiQRMgG5aN

---
_Generated by [Claude Code](https://claude.ai/code/session_0199DZfVd4fASrAiQRMgG5aN)_