### PR TITLE
Image: render the fallback when loading fails before hydration

### DIFF
--- a/.changeset/fix-image-fallback-before-hydration.md
+++ b/.changeset/fix-image-fallback-before-hydration.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Image: Rendered the fallback when a server rendered image fails to load before React hydrates the page

--- a/packages/reshaped/src/components/Image/Image.tsx
+++ b/packages/reshaped/src/components/Image/Image.tsx
@@ -27,6 +27,8 @@ const Image: React.FC<T.Props> = (props) => {
 		renderImage,
 	} = props;
 	const [status, setStatus] = React.useState("loading");
+	// Image attributes are merged on top of the root attributes when rendering the image element
+	const passedImageRef = passedImageAttributes?.ref ?? attributes?.ref;
 	const mixinStyles = resolveMixin({ radius: borderRadius, width, height, maxWidth, aspectRatio });
 	const rootClassNames = classNames(
 		s.root,
@@ -55,6 +57,22 @@ const Image: React.FC<T.Props> = (props) => {
 		onError?.(e);
 		passedImageAttributes?.onError?.(e);
 	};
+
+	const handleImageRef = React.useCallback(
+		(el: HTMLImageElement | null) => {
+			if (typeof passedImageRef === "function") passedImageRef(el);
+			else if (passedImageRef) passedImageRef.current = el;
+
+			// Server rendered images start loading before React hydrates,
+			// so their error event can fire before the error handler gets attached
+			if (!el || !src || !el.complete || el.naturalWidth > 0) return;
+
+			// Images without intrinsic dimensions, like svg with a viewBox only,
+			// are decoded successfully, while broken images reject the promise
+			el.decode().catch(() => setStatus("error"));
+		},
+		[passedImageRef, src]
+	);
 
 	React.useEffect(() => {
 		setStatus("loading");
@@ -90,6 +108,7 @@ const Image: React.FC<T.Props> = (props) => {
 		role: alt ? undefined : "presentation",
 		onLoad: handleLoad,
 		onError: handleError,
+		ref: handleImageRef,
 		className: outline ? imageClassNames : classNames([imageClassNames, rootClassNames]),
 		style,
 	};

--- a/packages/reshaped/src/components/Image/Image.tsx
+++ b/packages/reshaped/src/components/Image/Image.tsx
@@ -66,9 +66,6 @@ const Image: React.FC<T.Props> = (props) => {
 			// Server rendered images start loading before React hydrates,
 			// so their error event can fire before the error handler gets attached
 			if (!el || !src || !el.complete || el.naturalWidth > 0) return;
-
-			// Images without intrinsic dimensions, like svg with a viewBox only,
-			// are decoded successfully, while broken images reject the promise
 			el.decode().catch(() => setStatus("error"));
 		},
 		[passedImageRef, src]

--- a/packages/reshaped/src/components/Image/tests/Image.stories.tsx
+++ b/packages/reshaped/src/components/Image/tests/Image.stories.tsx
@@ -1,6 +1,4 @@
 import { StoryObj } from "@storybook/react-vite";
-import { flushSync } from "react-dom";
-import { createRoot, hydrateRoot } from "react-dom/client";
 import { expect, fn, Mock, waitFor } from "storybook/test";
 
 import Icon from "@/components/Icon";
@@ -263,41 +261,5 @@ export const imageAttributes: StoryObj = {
 		expect(root).toHaveClass("test-classname");
 		expect(root).toHaveAttribute("id", "test-id");
 		expect(img).toHaveAttribute("data-testid", "test-img-id");
-	},
-};
-
-export const fallbackBeforeHydration: StoryObj = {
-	name: "fallback, error before hydration",
-	render: () => <div data-testid="hydration-root" />,
-	play: async ({ canvas }) => {
-		const container = canvas.getByTestId("hydration-root");
-		const element = (
-			<Image src="/reshaped-missing-image.png" fallback={<span>Fallback content</span>} />
-		);
-
-		// Render the image once to get the markup matching the server rendered one
-		const markupContainer = document.createElement("div");
-		document.body.appendChild(markupContainer);
-		const markupRoot = createRoot(markupContainer);
-		flushSync(() => markupRoot.render(element));
-		const markup = markupContainer.innerHTML;
-		markupRoot.unmount();
-		markupContainer.remove();
-
-		// Let the server rendered image fail before React hydrates it
-		container.innerHTML = markup;
-		const img = container.querySelector("img")!;
-		await waitFor(() => expect(img.complete).toBe(true));
-		expect(img.naturalWidth).toBe(0);
-
-		const root = hydrateRoot(container, element);
-
-		try {
-			await waitFor(() => {
-				expect(container.textContent).toBe("Fallback content");
-			});
-		} finally {
-			root.unmount();
-		}
 	},
 };

--- a/packages/reshaped/src/components/Image/tests/Image.stories.tsx
+++ b/packages/reshaped/src/components/Image/tests/Image.stories.tsx
@@ -1,4 +1,6 @@
 import { StoryObj } from "@storybook/react-vite";
+import { flushSync } from "react-dom";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { expect, fn, Mock, waitFor } from "storybook/test";
 
 import Icon from "@/components/Icon";
@@ -261,5 +263,41 @@ export const imageAttributes: StoryObj = {
 		expect(root).toHaveClass("test-classname");
 		expect(root).toHaveAttribute("id", "test-id");
 		expect(img).toHaveAttribute("data-testid", "test-img-id");
+	},
+};
+
+export const fallbackBeforeHydration: StoryObj = {
+	name: "fallback, error before hydration",
+	render: () => <div data-testid="hydration-root" />,
+	play: async ({ canvas }) => {
+		const container = canvas.getByTestId("hydration-root");
+		const element = (
+			<Image src="/reshaped-missing-image.png" fallback={<span>Fallback content</span>} />
+		);
+
+		// Render the image once to get the markup matching the server rendered one
+		const markupContainer = document.createElement("div");
+		document.body.appendChild(markupContainer);
+		const markupRoot = createRoot(markupContainer);
+		flushSync(() => markupRoot.render(element));
+		const markup = markupContainer.innerHTML;
+		markupRoot.unmount();
+		markupContainer.remove();
+
+		// Let the server rendered image fail before React hydrates it
+		container.innerHTML = markup;
+		const img = container.querySelector("img")!;
+		await waitFor(() => expect(img.complete).toBe(true));
+		expect(img.naturalWidth).toBe(0);
+
+		const root = hydrateRoot(container, element);
+
+		try {
+			await waitFor(() => {
+				expect(container.textContent).toBe("Fallback content");
+			});
+		} finally {
+			root.unmount();
+		}
 	},
 };


### PR DESCRIPTION
## Summary

`Image` only learned about a failed load from its React `onError` handler, so a server rendered `<img>` that failed before hydration never moved `status` past `loading` and the `fallback` was never rendered — the browser's broken image icon stayed on screen.

The image element is now also checked when it gets mounted: if it already finished loading without intrinsic dimensions, `decode()` tells a genuinely broken image (rejects) apart from one that legitimately has no intrinsic size, like a `viewBox` only svg (resolves). Images that are still loading keep going through `onError` as before.

- `Image.tsx`: added a callback ref on the image element that detects an already failed load and switches the status to `error`. It composes with a `ref` passed through `imageAttributes` or `attributes`, so existing refs keep working, and it re-runs when `src` changes.
- Added a `fallback, error before hydration` story that reproduces the issue: it lets server rendered markup fail to load, then hydrates it and expects the fallback. The story fails on `main` and passes with this change.
- Added a patch changeset.

## Related Issue

Fixes #660

## Screenshots / Recordings

No visual changes to the existing states — the fallback simply renders in a case where the broken image icon used to show.

## Notes for Reviewers

- The status is only flipped to `error`; `onLoad` / `onError` callbacks are not synthesized for the pre-hydration case since there is no real event to pass to them.
- `decode()` is used instead of treating `naturalWidth === 0` as an error on its own to avoid false positives for svg images sized purely by CSS.
- Ran the Image storybook tests locally: everything passes except the pre-existing `onLoad` story, which needs network access to the Unsplash image URL that this sandbox does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UiNQ2AYKhZUEvdAtQ9Skaa

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiNQ2AYKhZUEvdAtQ9Skaa)_