### PR TITLE
Overlay: animate backdrop opacity instead of background-color

### DIFF
--- a/.changeset/overlay-backdrop-compositor.md
+++ b/.changeset/overlay-backdrop-compositor.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Improved the `Overlay` animation performance by rendering its backdrop as a separate layer with a static color and transitioning only its `opacity`. Previously the full-viewport root transitioned `background-color` on open and close and during the `Modal` drag-to-close gesture, which forced the browser to repaint the whole viewport on every frame on the main thread. The transition now runs entirely on the compositor thread while keeping the same visual result.

--- a/packages/reshaped/src/components/Overlay/Overlay.module.css
+++ b/packages/reshaped/src/components/Overlay/Overlay.module.css
@@ -2,7 +2,6 @@
 	/* Add an offset in case overlay is rendered inside a scrolled container */
 	--rs-overlay-offset-y: 0px;
 	--rs-overlay-offset-x: 0px;
-	--rs-overlay-opacity: 0;
 
 	position: fixed;
 	overflow-x: clip;
@@ -25,21 +24,20 @@
 	height: 100%;
 	width: 100%;
 	position: relative;
+}
 
-	/**
-	 * Backdrop is rendered as a separate layer with a static color and only its opacity is animated,
-	 * so the transition and the drag-to-close updates run on the compositor instead of repainting the whole viewport.
-	 * It's attached to the wrapper instead of the root to cover the whole scrollable area when overflow is auto.
-	 */
-	&::before {
-		content: "";
-		position: absolute;
-		inset: 0;
-		z-index: -1;
-		background-color: rgb(from var(--rs-color-black) r g b / 70%);
-		opacity: var(--rs-overlay-opacity);
-		will-change: opacity;
-	}
+/**
+ * Backdrop is rendered as a separate layer with a static color and only its opacity is animated,
+ * so the transition and the drag-to-close updates run on the compositor instead of repainting the whole viewport.
+ * It's rendered inside the wrapper instead of the root to cover the whole scrollable area when overflow is auto.
+ */
+.backdrop {
+	position: absolute;
+	inset: 0;
+	z-index: -1;
+	background-color: rgb(from var(--rs-color-black) r g b / 70%);
+	opacity: 0;
+	will-change: opacity;
 }
 
 .inner {
@@ -55,14 +53,20 @@
 }
 
 .root.--visible {
-	--rs-overlay-opacity: 1;
-
 	opacity: 1;
+
+	& .backdrop {
+		opacity: 1;
+	}
 }
 
 .root.--click-through {
 	color: inherit;
 	pointer-events: none;
+
+	& .backdrop {
+		opacity: 0;
+	}
 }
 
 .root.--blurred {
@@ -91,14 +95,14 @@
 	transition: var(--rs-duration-medium) var(--rs-easing-accelerate);
 	transition-property: opacity;
 
-	& .wrapper::before {
+	& .backdrop {
 		transition: opacity var(--rs-duration-medium) var(--rs-easing-accelerate);
 	}
 
 	&.--visible {
 		transition-timing-function: var(--rs-easing-decelerate);
 
-		& .wrapper::before {
+		& .backdrop {
 			transition-timing-function: var(--rs-easing-decelerate);
 		}
 	}

--- a/packages/reshaped/src/components/Overlay/Overlay.module.css
+++ b/packages/reshaped/src/components/Overlay/Overlay.module.css
@@ -15,7 +15,6 @@
 	width: 100%;
 	z-index: var(--rs-z-index-fixed);
 	color: var(--rs-color-white);
-	background-color: rgb(from var(--rs-color-black) r g b / 0%);
 	opacity: 0;
 	outline: none;
 	isolation: isolate;
@@ -25,6 +24,22 @@
 	display: table;
 	height: 100%;
 	width: 100%;
+	position: relative;
+
+	/**
+	 * Backdrop is rendered as a separate layer with a static color and only its opacity is animated,
+	 * so the transition and the drag-to-close updates run on the compositor instead of repainting the whole viewport.
+	 * It's attached to the wrapper instead of the root to cover the whole scrollable area when overflow is auto.
+	 */
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		background-color: rgb(from var(--rs-color-black) r g b / 70%);
+		opacity: var(--rs-overlay-opacity);
+		will-change: opacity;
+	}
 }
 
 .inner {
@@ -42,7 +57,6 @@
 .root.--visible {
 	--rs-overlay-opacity: 1;
 
-	background-color: rgb(from var(--rs-color-black) r g b / calc(var(--rs-overlay-opacity) * 0.7));
 	opacity: 1;
 }
 
@@ -75,10 +89,18 @@
 
 .root.--animated {
 	transition: var(--rs-duration-medium) var(--rs-easing-accelerate);
-	transition-property: background-color, opacity;
+	transition-property: opacity;
+
+	& .wrapper::before {
+		transition: opacity var(--rs-duration-medium) var(--rs-easing-accelerate);
+	}
 
 	&.--visible {
 		transition-timing-function: var(--rs-easing-decelerate);
+
+		& .wrapper::before {
+			transition-timing-function: var(--rs-easing-decelerate);
+		}
 	}
 }
 

--- a/packages/reshaped/src/components/Overlay/Overlay.module.css
+++ b/packages/reshaped/src/components/Overlay/Overlay.module.css
@@ -26,11 +26,7 @@
 	position: relative;
 }
 
-/**
- * Backdrop is rendered as a separate layer with a static color and only its opacity is animated,
- * so the transition and the drag-to-close updates run on the compositor instead of repainting the whole viewport.
- * It's rendered inside the wrapper instead of the root to cover the whole scrollable area when overflow is auto.
- */
+/* Setting opacity separately for swipe updates directly in the dom */
 .backdrop {
 	position: absolute;
 	inset: 0;
@@ -92,8 +88,7 @@
 }
 
 .root.--animated {
-	transition: var(--rs-duration-medium) var(--rs-easing-accelerate);
-	transition-property: opacity;
+	transition: opacity var(--rs-duration-medium) var(--rs-easing-accelerate);
 
 	& .backdrop {
 		transition: opacity var(--rs-duration-medium) var(--rs-easing-accelerate);

--- a/packages/reshaped/src/components/Overlay/Overlay.tsx
+++ b/packages/reshaped/src/components/Overlay/Overlay.tsx
@@ -42,6 +42,7 @@ const Overlay: React.FC<T.Props> = (props) => {
 	const [animated, setAnimated] = React.useState(false);
 	const [offset, setOffset] = React.useState([0, 0]);
 	const rootRef = React.useRef<HTMLDivElement>(null);
+	const backdropRef = React.useRef<HTMLDivElement>(null);
 	const scopeRef = React.useRef<HTMLDivElement>(null);
 	const contentRef = React.useRef<HTMLDivElement>(null);
 	const { lockScroll, unlockScroll } = useScrollLock({ containerRef });
@@ -183,7 +184,8 @@ const Overlay: React.FC<T.Props> = (props) => {
 		() => ({
 			setOpacity: (value: number) => {
 				if (transparent) return;
-				rootRef.current?.style.setProperty("--rs-overlay-opacity", `${value}`);
+				// Applied directly to the backdrop element to keep the style recalculation scoped to it
+				backdropRef.current?.style.setProperty("opacity", `${value}`);
 			},
 		}),
 		[transparent]
@@ -205,7 +207,6 @@ const Overlay: React.FC<T.Props> = (props) => {
 							{
 								"--rs-overlay-offset-x": containerRef ? `${offset[0]}px` : undefined,
 								"--rs-overlay-offset-y": containerRef ? `${offset[1]}px` : undefined,
-								"--rs-overlay-opacity": transparent ? 0 : undefined,
 							} as React.CSSProperties
 						}
 						// oxlint-disable-next-line jsx_a11y/prefer-tag-over-role
@@ -217,6 +218,7 @@ const Overlay: React.FC<T.Props> = (props) => {
 						onTransitionEnd={handleTransitionEnd}
 					>
 						<div className={s.wrapper}>
+							<div className={s.backdrop} ref={backdropRef} />
 							<div className={s.inner}>
 								<div className={s.content} ref={contentRef}>
 									{typeof children === "function" ? children({ active: visible }) : children}


### PR DESCRIPTION
## Summary

Following the guidance in [The Browser's Main Thread Is Expensive](https://kciter.so/posts/the-expensive-main-thread/en/): only `transform` and `opacity` can be animated on the compositor thread, everything else forces style/layout/paint work on the main thread every frame.

The `Overlay` root is a `position: fixed` element covering the whole viewport. It transitioned `background-color` (0% → 70% black) together with `opacity` on open/close, and `Modal` updated that `background-color` on every frame of the drag-to-close gesture through the inherited `--rs-overlay-opacity` custom property. Every one of those frames repainted the full viewport on the main thread, and the custom property change on the root also forced a style recalculation of the entire overlay subtree (the whole modal content).

This PR renders the backdrop as a dedicated `.backdrop` element with a **static** 70% black background and animates only its `opacity`:

- Open/close: `.backdrop` transitions `opacity` with the same duration/easing as the root, so the resulting fade curve (`0.7 · t²`) is unchanged and runs on the compositor.
- Drag-to-close: `instanceRef.setOpacity()` now writes `style.opacity` directly on the backdrop element, so the update is scoped to that single element instead of invalidating style for every descendant. Measured in Chromium: updating an inherited custom property on the root of a 6000-node subtree costs ~10ms of style recalc per update, versus ~0.01ms for a direct opacity write on one element.
- The backdrop lives inside the wrapper (a `display: table` box that grows with the content) so it keeps covering the whole scrollable area when `overflow="auto"` is used by centered modals.
- `transparent` and `blurred` variants keep working: `transparent` sets the backdrop opacity to 0 via the existing `--click-through` class, `backdrop-filter` stays on the root.
- The internal `--rs-overlay-opacity` custom property is removed; the public `instanceRef.setOpacity()` API is unchanged.

## Related Issue

N/A

## Screenshots / Recordings

Verified in headless Chromium against Storybook: the blurred, transparent, and tall centered (scrolled `overflow: auto`) modal states are pixel-identical to `main` at rest, the backdrop still covers the viewport when the overlay is scrolled to the bottom, and a simulated touch drag on a bottom modal dims the backdrop (opacity 0.68 at 88px of drag) and closes on release.

## Notes for Reviewers

- Overlay and Modal story tests pass locally (23 tests).
- The `will-change: opacity` on the backdrop keeps it promoted between drag updates so `setOpacity()` calls don't trigger repaints; the layer only exists while an overlay is rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAi9QQVSFuJ7Gkf8SUTYJq