### PR TITLE
ScrollArea: move the thumb with transform instead of inset

### DIFF
--- a/.changeset/scroll-area-thumb-compositor.md
+++ b/.changeset/scroll-area-thumb-compositor.md
@@ -1,0 +1,5 @@
+---
+"reshaped": patch
+---
+
+Improved the `ScrollArea` scrolling performance. The custom scrollbar thumb now follows the scroll position with a `transform` instead of `inset`, so the scroll-linked updates run on the compositor thread without triggering layout and paint, and the scroll position is written directly to a css variable instead of re-rendering the component on every scroll event. This also fixes the horizontal thumb moving outside of the scrollbar track when scrolling in RTL.

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
@@ -194,11 +194,6 @@
 	opacity: 0;
 	transition: opacity var(--rs-duration-fast) var(--rs-easing-standard);
 
-	/**
-	 * Thumb position follows the scroll with a transform instead of inset,
-	 * so the scroll-linked updates run on the compositor without triggering layout and paint.
-	 * The translate percentage is relative to the thumb size, so the position is divided by the ratio.
-	 */
 	&::before {
 		content: "";
 		display: block;

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
@@ -194,6 +194,11 @@
 	opacity: 0;
 	transition: opacity var(--rs-duration-fast) var(--rs-easing-standard);
 
+	/**
+	 * Thumb position follows the scroll with a transform instead of inset,
+	 * so the scroll-linked updates run on the compositor without triggering layout and paint.
+	 * The translate percentage is relative to the thumb size, so the position is divided by the ratio.
+	 */
 	&::before {
 		content: "";
 		display: block;
@@ -202,6 +207,7 @@
 		transition: opacity var(--rs-duration-fast) var(--rs-easing-standard);
 		position: absolute;
 		opacity: 0.2;
+		will-change: transform;
 	}
 }
 
@@ -212,9 +218,12 @@
 	padding-block: calc(var(--rs-scroll-area-thumb-offset) + var(--rs-unit-x1));
 
 	& .thumb::before {
-		inset-block-start: calc(var(--rs-scroll-area-position) * 100%);
+		inset-block-start: 0;
 		width: 100%;
 		height: calc(var(--rs-scroll-area-ratio) * 100%);
+		transform: translateY(
+			calc(var(--rs-scroll-area-position-y, 0) / var(--rs-scroll-area-ratio) * 100%)
+		);
 	}
 }
 
@@ -225,9 +234,12 @@
 	padding-inline: calc(var(--rs-scroll-area-thumb-offset) + var(--rs-unit-x0-5));
 
 	& .thumb::before {
-		inset-inline-start: calc(var(--rs-scroll-area-position) * 100%);
+		inset-inline-start: 0;
 		height: 100%;
 		width: calc(var(--rs-scroll-area-ratio) * 100%);
+		transform: translateX(
+			calc(var(--rs-scroll-area-position-x, 0) / var(--rs-scroll-area-ratio) * 100%)
+		);
 	}
 }
 

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.module.css
@@ -222,7 +222,7 @@
 		width: 100%;
 		height: calc(var(--rs-scroll-area-ratio) * 100%);
 		transform: translateY(
-			calc(var(--rs-scroll-area-position-y, 0) / var(--rs-scroll-area-ratio) * 100%)
+			calc(var(--rs-scroll-area-position, 0) / var(--rs-scroll-area-ratio) * 100%)
 		);
 	}
 }
@@ -238,7 +238,7 @@
 		height: 100%;
 		width: calc(var(--rs-scroll-area-ratio) * 100%);
 		transform: translateX(
-			calc(var(--rs-scroll-area-position-x, 0) / var(--rs-scroll-area-ratio) * 100%)
+			calc(var(--rs-scroll-area-position, 0) / var(--rs-scroll-area-ratio) * 100%)
 		);
 	}
 }

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
@@ -2,7 +2,7 @@
 
 import React, { forwardRef } from "react";
 import { classNames } from "@reshaped/utilities";
-import { disableScroll, enableScroll } from "@reshaped/utilities/internal";
+import { disableScroll, enableScroll, type Coordinates } from "@reshaped/utilities/internal";
 
 import useHandlerRef from "@/hooks/useHandlerRef";
 import useIsomorphicLayoutEffect from "@/hooks/useIsomorphicLayoutEffect";
@@ -11,7 +11,7 @@ import type * as T from "./ScrollArea.types";
 import s from "./ScrollArea.module.css";
 
 const ScrollAreaBar: React.FC<T.BarProps> = (props) => {
-	const { ratio, position, vertical, onThumbMove } = props;
+	const { ratio, vertical, onThumbMove } = props;
 	const onThumbMoveRef = useHandlerRef(onThumbMove);
 	const [dragging, setDragging] = React.useState(false);
 	const dragStartPositionRef = React.useRef(0);
@@ -81,12 +81,7 @@ const ScrollAreaBar: React.FC<T.BarProps> = (props) => {
 	return (
 		<div
 			className={barClassNames}
-			style={
-				{
-					"--rs-scroll-area-ratio": ratio,
-					"--rs-scroll-area-position": position,
-				} as React.CSSProperties
-			}
+			style={{ "--rs-scroll-area-ratio": ratio } as React.CSSProperties}
 			ref={barRef}
 			onClick={handleClick}
 			onMouseDown={handleDragStart}
@@ -113,7 +108,6 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 		scrollableClassName,
 	} = props;
 	const [scrollRatio, setScrollRatio] = React.useState({ x: 1, y: 1 });
-	const [scrollPosition, setScrollPosition] = React.useState({ x: 0, y: 0 });
 	const [scrolling, setScrolling] = React.useState(false);
 	const scrollingTimeoutRef = React.useRef<ReturnType<typeof setTimeout>>(undefined);
 	const scrollableRef = React.useRef<HTMLDivElement>(null);
@@ -134,6 +128,18 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 		fade && s["--fade"]
 	);
 
+	/**
+	 * Scroll position is written directly to the css variables instead of the react state,
+	 * so the scroll events don't re-render the component on every frame
+	 */
+	const setScrollPosition = React.useCallback((position: Coordinates) => {
+		const rootEl = rootRef.current;
+		if (!rootEl) return;
+
+		rootEl.style.setProperty("--rs-scroll-area-position-x", `${position.x}`);
+		rootEl.style.setProperty("--rs-scroll-area-position-y", `${position.y}`);
+	}, []);
+
 	const updateScroll = React.useCallback(() => {
 		const scrollableEl = scrollableRef.current;
 		if (!scrollableEl) return;
@@ -149,7 +155,7 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 			x: scrollWidth <= clientWidth ? 0 : scrollLeft / scrollWidth,
 			y: scrollHeight <= clientHeight ? 0 : scrollTop / scrollHeight,
 		});
-	}, []);
+	}, [setScrollPosition]);
 
 	const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
 		const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
@@ -248,19 +254,10 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 				</div>
 			</div>
 			{orientation !== "horizontal" && scrollRatio.y < 1 && scrollbarDisplay !== "hidden" && (
-				<ScrollAreaBar
-					vertical
-					onThumbMove={handleThumbYMove}
-					ratio={scrollRatio.y}
-					position={scrollPosition.y}
-				/>
+				<ScrollAreaBar vertical onThumbMove={handleThumbYMove} ratio={scrollRatio.y} />
 			)}
 			{orientation !== "vertical" && scrollRatio.x < 1 && scrollbarDisplay !== "hidden" && (
-				<ScrollAreaBar
-					onThumbMove={handleThumbXMove}
-					ratio={scrollRatio.x}
-					position={scrollPosition.x}
-				/>
+				<ScrollAreaBar onThumbMove={handleThumbXMove} ratio={scrollRatio.x} />
 			)}
 		</div>
 	);

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
@@ -16,36 +16,6 @@ const ScrollAreaBar: React.FC<T.BarProps> = (props) => {
 	const [dragging, setDragging] = React.useState(false);
 	const dragStartPositionRef = React.useRef(0);
 	const barRef = React.useRef<HTMLDivElement>(null);
-
-	/**
-	 * Thumb position is written directly to a css variable on the bar instead of the react state,
-	 * so scrolling doesn't re-render the component and the style recalculation stays scoped to the bar
-	 */
-	useIsomorphicLayoutEffect(() => {
-		const scrollableEl = scrollableRef.current;
-		const barEl = barRef.current;
-		if (!scrollableEl || !barEl) return;
-
-		const updatePosition = () => {
-			const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
-				scrollableEl;
-			const position = vertical
-				? scrollHeight <= clientHeight
-					? 0
-					: scrollTop / scrollHeight
-				: scrollWidth <= clientWidth
-					? 0
-					: scrollLeft / scrollWidth;
-
-			barEl.style.setProperty("--rs-scroll-area-position", `${position}`);
-		};
-
-		updatePosition();
-		scrollableEl.addEventListener("scroll", updatePosition, { passive: true });
-
-		return () => scrollableEl.removeEventListener("scroll", updatePosition);
-		// Ratio is included to re-sync the position after the content or the container size changes
-	}, [vertical, scrollableRef, ratio]);
 	const barClassNames = classNames(
 		s.scrollbar,
 		vertical ? s["--scrollbar-y"] : s["--scrollbar-x"],
@@ -95,6 +65,36 @@ const ScrollAreaBar: React.FC<T.BarProps> = (props) => {
 		setDragging(false);
 		enableScroll();
 	}, []);
+
+	/**
+	 * Thumb position is written directly to a css variable on the bar instead of the react state,
+	 * so scrolling doesn't re-render the component and the style recalculation stays scoped to the bar
+	 */
+	useIsomorphicLayoutEffect(() => {
+		const scrollableEl = scrollableRef.current;
+		const barEl = barRef.current;
+		if (!scrollableEl || !barEl) return;
+
+		const updatePosition = () => {
+			const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
+				scrollableEl;
+			const position = vertical
+				? scrollHeight <= clientHeight
+					? 0
+					: scrollTop / scrollHeight
+				: scrollWidth <= clientWidth
+					? 0
+					: scrollLeft / scrollWidth;
+
+			barEl.style.setProperty("--rs-scroll-area-position", `${position}`);
+		};
+
+		updatePosition();
+		scrollableEl.addEventListener("scroll", updatePosition, { passive: true });
+
+		return () => scrollableEl.removeEventListener("scroll", updatePosition);
+		// Ratio is included to re-sync the position after the content or the container size changes
+	}, [vertical, scrollableRef, ratio]);
 
 	React.useEffect(() => {
 		if (!dragging) return;

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.tsx
@@ -2,7 +2,7 @@
 
 import React, { forwardRef } from "react";
 import { classNames } from "@reshaped/utilities";
-import { disableScroll, enableScroll, type Coordinates } from "@reshaped/utilities/internal";
+import { disableScroll, enableScroll } from "@reshaped/utilities/internal";
 
 import useHandlerRef from "@/hooks/useHandlerRef";
 import useIsomorphicLayoutEffect from "@/hooks/useIsomorphicLayoutEffect";
@@ -11,11 +11,41 @@ import type * as T from "./ScrollArea.types";
 import s from "./ScrollArea.module.css";
 
 const ScrollAreaBar: React.FC<T.BarProps> = (props) => {
-	const { ratio, vertical, onThumbMove } = props;
+	const { ratio, vertical, scrollableRef, onThumbMove } = props;
 	const onThumbMoveRef = useHandlerRef(onThumbMove);
 	const [dragging, setDragging] = React.useState(false);
 	const dragStartPositionRef = React.useRef(0);
 	const barRef = React.useRef<HTMLDivElement>(null);
+
+	/**
+	 * Thumb position is written directly to a css variable on the bar instead of the react state,
+	 * so scrolling doesn't re-render the component and the style recalculation stays scoped to the bar
+	 */
+	useIsomorphicLayoutEffect(() => {
+		const scrollableEl = scrollableRef.current;
+		const barEl = barRef.current;
+		if (!scrollableEl || !barEl) return;
+
+		const updatePosition = () => {
+			const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
+				scrollableEl;
+			const position = vertical
+				? scrollHeight <= clientHeight
+					? 0
+					: scrollTop / scrollHeight
+				: scrollWidth <= clientWidth
+					? 0
+					: scrollLeft / scrollWidth;
+
+			barEl.style.setProperty("--rs-scroll-area-position", `${position}`);
+		};
+
+		updatePosition();
+		scrollableEl.addEventListener("scroll", updatePosition, { passive: true });
+
+		return () => scrollableEl.removeEventListener("scroll", updatePosition);
+		// Ratio is included to re-sync the position after the content or the container size changes
+	}, [vertical, scrollableRef, ratio]);
 	const barClassNames = classNames(
 		s.scrollbar,
 		vertical ? s["--scrollbar-y"] : s["--scrollbar-x"],
@@ -128,34 +158,17 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 		fade && s["--fade"]
 	);
 
-	/**
-	 * Scroll position is written directly to the css variables instead of the react state,
-	 * so the scroll events don't re-render the component on every frame
-	 */
-	const setScrollPosition = React.useCallback((position: Coordinates) => {
-		const rootEl = rootRef.current;
-		if (!rootEl) return;
-
-		rootEl.style.setProperty("--rs-scroll-area-position-x", `${position.x}`);
-		rootEl.style.setProperty("--rs-scroll-area-position-y", `${position.y}`);
-	}, []);
-
 	const updateScroll = React.useCallback(() => {
 		const scrollableEl = scrollableRef.current;
 		if (!scrollableEl) return;
 
-		const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
-			scrollableEl;
+		const { clientWidth, clientHeight, scrollWidth, scrollHeight } = scrollableEl;
 
 		setScrollRatio({
 			x: scrollWidth === 0 ? 1 : Math.min(clientWidth / scrollWidth, 1),
 			y: scrollHeight === 0 ? 1 : Math.min(clientHeight / scrollHeight, 1),
 		});
-		setScrollPosition({
-			x: scrollWidth <= clientWidth ? 0 : scrollLeft / scrollWidth,
-			y: scrollHeight <= clientHeight ? 0 : scrollTop / scrollHeight,
-		});
-	}, [setScrollPosition]);
+	}, []);
 
 	const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
 		const { scrollLeft, scrollTop, clientWidth, clientHeight, scrollWidth, scrollHeight } =
@@ -167,10 +180,6 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 			scrollingTimeoutRef.current = setTimeout(() => setScrolling(false), 1000);
 		}
 
-		setScrollPosition({
-			x: scrollLeft / scrollWidth,
-			y: scrollTop / scrollHeight,
-		});
 		onScroll?.({
 			x: scrollWidth === clientWidth ? 0 : scrollLeft / (scrollWidth - clientWidth),
 			y: scrollHeight === clientHeight ? 0 : scrollTop / (scrollHeight - clientHeight),
@@ -254,10 +263,19 @@ const ScrollArea = forwardRef<HTMLDivElement, T.Props>((props, ref) => {
 				</div>
 			</div>
 			{orientation !== "horizontal" && scrollRatio.y < 1 && scrollbarDisplay !== "hidden" && (
-				<ScrollAreaBar vertical onThumbMove={handleThumbYMove} ratio={scrollRatio.y} />
+				<ScrollAreaBar
+					vertical
+					onThumbMove={handleThumbYMove}
+					ratio={scrollRatio.y}
+					scrollableRef={scrollableRef}
+				/>
 			)}
 			{orientation !== "vertical" && scrollRatio.x < 1 && scrollbarDisplay !== "hidden" && (
-				<ScrollAreaBar onThumbMove={handleThumbXMove} ratio={scrollRatio.x} />
+				<ScrollAreaBar
+					onThumbMove={handleThumbXMove}
+					ratio={scrollRatio.x}
+					scrollableRef={scrollableRef}
+				/>
 			)}
 		</div>
 	);

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.types.ts
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.types.ts
@@ -34,7 +34,6 @@ export type Props = {
 
 export type BarProps = {
 	ratio: number;
-	position: number;
 	vertical?: boolean;
 	onThumbMove: (args: { value: number; type: "absolute" | "relative" }) => void;
 };

--- a/packages/reshaped/src/components/ScrollArea/ScrollArea.types.ts
+++ b/packages/reshaped/src/components/ScrollArea/ScrollArea.types.ts
@@ -35,5 +35,6 @@ export type Props = {
 export type BarProps = {
 	ratio: number;
 	vertical?: boolean;
+	scrollableRef: React.RefObject<HTMLElement | null>;
 	onThumbMove: (args: { value: number; type: "absolute" | "relative" }) => void;
 };


### PR DESCRIPTION
## Summary

Following the guidance in [The Browser's Main Thread Is Expensive](https://kciter.so/posts/the-expensive-main-thread/en/): scroll-linked visuals should be driven by `transform`/`opacity` on the compositor, not by layout properties updated from JavaScript on every frame.

`ScrollArea`'s custom scrollbar previously did the most expensive version of this on every `scroll` event:

1. `handleScroll` called `setScrollPosition`, re-rendering `ScrollArea` and both `ScrollAreaBar`s through React.
2. The new position was applied to the thumb's `::before` via `inset-block-start` / `inset-inline-start`, which are layout properties, so each scroll frame ran style → layout → paint on the main thread.

This PR:

- **Moves the thumb with `transform: translateX/translateY`** instead of `inset`. The translate percentage is relative to the thumb's own size, so the position is divided by the ratio to map it back onto the track (`position / ratio * 100%`). The thumb pseudo-element gets `will-change: transform` so it stays on its own compositor layer between updates.
- **Lets each bar track the scrollable element itself.** `ScrollAreaBar` receives the `scrollableRef`, attaches a passive `scroll` listener, and writes `--rs-scroll-area-position` onto its own element. Scroll events no longer re-render anything, and the style recalculation stays scoped to the bar (writing an inherited custom property on the root instead would invalidate every node of the scrolled content: measured ~10ms per update on a 6000-node subtree in Chromium, versus ~0.02ms on the bar). The position is re-synced whenever the `ratio` changes, which covers the ResizeObserver/MutationObserver paths.
- Keeps the scroll *ratio* in React state, since it decides whether a bar is rendered at all and only changes on resize/mutation.
- Replaces the `position` prop on the internal `BarProps` with `scrollableRef`.

Since the translate is physical, this also **fixes the horizontal thumb in RTL**: `scrollLeft` is negative in RTL, and applying it to `inset-inline-start` pushed the thumb outside the track (measured `left: 509.8px` for a 549px-wide thumb in an ~824px track on `main`). It now moves left inside the track as expected.

## Related Issue

N/A

## Screenshots / Recordings

Verified in headless Chromium against the `base` story by measuring the thumb geometry at several scroll offsets:

- LTR: thumb position and size are identical to `main` at rest and when scrolled (vertical, horizontal and both).
- RTL: identical at rest; when scrolled, the thumb now stays inside the track instead of overflowing it.

## Notes for Reviewers

- ScrollArea, Table and Autocomplete story tests pass locally (23 tests).
- The imperative `style.setProperty` on the bar follows the same pattern already used by `Modal` (`--rs-modal-drag`) and `Slider` (`--rs-slider-tooltip-offset`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAi9QQVSFuJ7Gkf8SUTYJq